### PR TITLE
Fix type inference issue for UUID conversion in build_dummy_version_message 

### DIFF
--- a/cli/src/modules/guide.txt
+++ b/cli/src/modules/guide.txt
@@ -1,6 +1,6 @@
 Please note - this is an alpha version of the softeware, not all features are currently functional.
 
-If using a dekstop or a web version of this software, you can use Ctrl+'+' or Ctrl+'-' (Command on MacOS) to
+If using a desktop or a web version of this software, you can use Ctrl+'+' or Ctrl+'-' (Command on MacOS) to
 change the terminal font size.
 
 If using a desktop version, you can use Ctrl+M (Command on MacOS) to bring up metrics.

--- a/components/addressmanager/src/lib.rs
+++ b/components/addressmanager/src/lib.rs
@@ -596,7 +596,7 @@ mod address_store_with_cache {
             // The target uniform distribution
             let target_u_dist = Uniform::new(0.0, (num_of_buckets) as f64).unwrap();
             for _ in 0..num_of_trials {
-                // The weight sampled expected uniform distibution
+                // The weight sampled expected uniform distribution
                 let prioritized_address_distribution = am
                     .lock()
                     .iterate_prioritized_random_addresses(HashSet::new())

--- a/components/consensusmanager/src/lib.rs
+++ b/components/consensusmanager/src/lib.rs
@@ -212,7 +212,7 @@ impl StagingConsensus {
         // Drop `prev` so that deletion below succeeds
         drop(prev);
         // Staging was committed and is now the active consensus so we can delete
-        // any pervious, now inactive, consensus entries
+        // any previous, now inactive, consensus entries
         self.manager.delete_inactive_consensus_entries();
     }
 

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -2749,7 +2749,7 @@ mod test {
             (1u64, vec![], false),                                // Case 1: 0 = locktime < txLockTime
             (0x800000, vec![0x7f, 0, 0], false),                  // Case 2: 0 < locktime < txLockTime
             (0x800000, vec![0x7f, 0, 0, 0, 0, 0, 0, 0, 0], true), // Case 3: locktime too big
-            (LOCK_TIME_THRESHOLD * 2, vec![0x7f, 0, 0, 0], true), // Case 4: lock times are inconsistant
+            (LOCK_TIME_THRESHOLD * 2, vec![0x7f, 0, 0, 0], true), // Case 4: lock times are inconsistent
         ] {
             let mut tx = base_tx.clone();
             tx.0.lock_time = tx_lock_time;

--- a/protocol/p2p/src/echo.rs
+++ b/protocol/p2p/src/echo.rs
@@ -96,7 +96,7 @@ fn build_dummy_version_message() -> VersionMessage {
         services: 0,
         timestamp: unix_now() as i64,
         address: None,
-        id: Vec::from(Uuid::new_v4().as_ref()),
+        id: Vec::from(Uuid::new_v4().as_bytes()),
         user_agent: String::new(),
         disable_relay_tx: false,
         subnetwork_id: None,

--- a/wasm/examples/nodejs/javascript/transactions/generator.js
+++ b/wasm/examples/nodejs/javascript/transactions/generator.js
@@ -67,7 +67,7 @@ const { encoding, networkId, address : destinationAddress } = require("../utils"
         // to the change address.
         //
         // If the requested amount is greater than the Spectre
-        // transactoin mass, the Generator will create multiple
+        // transaction mass, the Generator will create multiple
         // transactions where each transaction will forward
         // UTXOs to the change address, until the requested
         // amount is reached.  It will then create a final


### PR DESCRIPTION
- Updated `build_dummy_version_message` to use `Uuid::new_v4().as_bytes()` for converting UUID to `Vec<u8>`

Closes #1 

