### PR TITLE
watch-only account implementation

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -72,6 +72,9 @@ pub enum Error {
     #[error("wallet secret is required")]
     WalletSecretRequired,
 
+    #[error("watch-only wallet kpub is required")]
+    WalletBip32WatchXpubRequired,
+
     #[error("wallet secrets do not match")]
     WalletSecretMatch,
 
@@ -83,6 +86,9 @@ pub enum Error {
 
     #[error("key data not found")]
     KeyDataNotFound,
+
+    #[error("no key data to export for watch-only account")]
+    WatchOnlyAccountNoKeyData,
 
     #[error("no accounts found, please create an account to continue")]
     NoAccounts,

--- a/cli/src/modules/account.rs
+++ b/cli/src/modules/account.rs
@@ -205,7 +205,7 @@ impl Account {
                     }
                     _ => {
                         tprintln!(ctx, "Unknown account import type: '{}'", import_kind);
-                        tprintln!(ctx, "supported import types are: 'mnemonic', 'legacy-data' or 'multisig-watch'\r\n");
+                        tprintln!(ctx, "Supported import types are: 'mnemonic', 'legacy-data' or 'multisig-watch'\r\n");
                         return Ok(());
                     }
                 }

--- a/cli/src/modules/account.rs
+++ b/cli/src/modules/account.rs
@@ -84,6 +84,8 @@ impl Account {
                                 "account import mnemonic multisig [additional keys]",
                                 "Import mnemonic and additional keys for a multisig account",
                             ),
+                            ("account import bip32-watch", "Import a extended public key for a watch-only bip32 account"),
+                            ("account import multisig-watch", "Import extended public keys for a watch-only multisig account"),
                         ],
                         None,
                     )?;
@@ -174,9 +176,36 @@ impl Account {
 
                         return Ok(());
                     }
+                    "bip32-watch" => {
+                        let account_name = if argv.is_empty() {
+                            None
+                        } else {
+                            let name = argv.remove(0);
+                            let name = name.trim().to_string();
+                            Some(name)
+                        };
+
+                        let account_name = account_name.as_deref();
+                        wizards::account::bip32_watch(&ctx, account_name).await?;
+                    }
+                    "multisig-watch" => {
+                        let account_name = if argv.is_empty() {
+                            None
+                        } else {
+                            let name = argv.remove(0);
+                            let name = name.trim().to_string();
+
+                            Some(name)
+                        };
+
+                        let account_name = account_name.as_deref();
+                        wizards::account::multisig_watch(&ctx, account_name).await?;
+
+                        return Ok(());
+                    }
                     _ => {
                         tprintln!(ctx, "Unknown account import type: '{}'", import_kind);
-                        tprintln!(ctx, "Supported import types are: 'mnemonic' or 'legacy-data'\r\n");
+                        tprintln!(ctx, "supported import types are: 'mnemonic', 'legacy-data' or 'multisig-watch'\r\n");
                         return Ok(());
                     }
                 }

--- a/cli/src/modules/details.rs
+++ b/cli/src/modules/details.rs
@@ -25,7 +25,7 @@ impl Details {
                     tprintln!(ctx.term(), "Feature: {}", style(feature).cyan());
                 }
                 tprintln!(ctx.term(), "Extended public keys:");
-                xpub_keys.iter().enumerate().for_each(|(_idx, xpub)| {
+                xpub_keys.iter().for_each(|xpub| {
                     tprintln!(ctx.term(), "{:>4}{}", "", style(ctx.wallet().network_format_xpub(xpub)).dim());
                 });
             }

--- a/cli/src/modules/details.rs
+++ b/cli/src/modules/details.rs
@@ -19,6 +19,18 @@ impl Details {
             tprintln!(ctx.term(), "{:>4}{}", "", style(address.to_string()).blue());
         });
 
+        if let Some(xpub_keys) = account.xpub_keys() {
+            if account.feature().is_some() {
+                if let Some(feature) = account.feature() {
+                    tprintln!(ctx.term(), "Feature: {}", style(feature).cyan());
+                }
+                tprintln!(ctx.term(), "Extended public keys:");
+                xpub_keys.iter().enumerate().for_each(|(_idx, xpub)| {
+                    tprintln!(ctx.term(), "{:>4}{}", "", style(ctx.wallet().network_format_xpub(xpub)).dim());
+                });
+            }
+        }
+
         let manager = derivation.change_address_manager();
         let index = manager.index() + 1;
         let addresses = manager.get_range_with_args(0..index, false)?;

--- a/cli/src/modules/export.rs
+++ b/cli/src/modules/export.rs
@@ -1,5 +1,5 @@
 use crate::imports::*;
-use spectre_wallet_core::account::{multisig::MultiSig, Account, MULTISIG_ACCOUNT_KIND};
+use spectre_wallet_core::account::{multisig::MultiSig, Account, BIP32_ACCOUNT_KIND, MULTISIG_ACCOUNT_KIND};
 
 #[derive(Default, Handler)]
 #[help("Export transactions, a wallet or a private key")]
@@ -32,8 +32,8 @@ impl Export {
 
 async fn export_multisig_account(ctx: Arc<SpectreCli>, account: Arc<MultiSig>) -> Result<()> {
     match &account.prv_key_data_ids() {
-        None => Err(Error::KeyDataNotFound),
-        Some(v) if v.is_empty() => Err(Error::KeyDataNotFound),
+        None => Err(Error::WatchOnlyAccountNoKeyData),
+        Some(v) if v.is_empty() => Err(Error::WatchOnlyAccountNoKeyData),
         Some(prv_key_data_ids) => {
             let wallet_secret = Secret::new(ctx.term().ask(true, "Enter wallet password: ").await?.trim().as_bytes().to_vec());
             if wallet_secret.as_ref().is_empty() {
@@ -45,26 +45,38 @@ async fn export_multisig_account(ctx: Arc<SpectreCli>, account: Arc<MultiSig>) -
 
             let prv_key_data_store = ctx.store().as_prv_key_data_store()?;
             let mut generated_xpub_keys = Vec::with_capacity(prv_key_data_ids.len());
+
             for (id, prv_key_data_id) in prv_key_data_ids.iter().enumerate() {
                 let prv_key_data = prv_key_data_store.load_key_data(&wallet_secret, prv_key_data_id).await?.unwrap();
                 let mnemonic = prv_key_data.as_mnemonic(None).unwrap().unwrap();
 
-                tprintln!(ctx, "Mnemonic {}:", id + 1);
+                let xpub_key: spectre_bip32::ExtendedPublicKey<spectre_bip32::secp256k1::PublicKey> =
+                    prv_key_data.create_xpub(None, MULTISIG_ACCOUNT_KIND.into(), 0).await?; // todo it can be done concurrently
+
+                tprintln!(ctx, "");
+                tprintln!(ctx, "extended public key {}:", id + 1);
+                tprintln!(ctx, "");
+                tprintln!(ctx, "{}", ctx.wallet().network_format_xpub(&xpub_key));
+                tprintln!(ctx, "");
+
+                tprintln!(ctx, "mnemonic {}:", id + 1);
                 tprintln!(ctx, "");
                 tprintln!(ctx, "{}", mnemonic.phrase());
                 tprintln!(ctx, "");
 
-                let xpub_key = prv_key_data.create_xpub(None, MULTISIG_ACCOUNT_KIND.into(), 0).await?; // todo it can be done concurrently
                 generated_xpub_keys.push(xpub_key);
             }
+            let test = account.xpub_keys();
 
-            let additional = account.xpub_keys().iter().filter(|xpub| !generated_xpub_keys.contains(xpub));
-            additional.enumerate().for_each(|(idx, xpub)| {
-                if idx == 0 {
-                    tprintln!(ctx, "Additional xpubs: ");
-                }
-                tprintln!(ctx, "{xpub}");
-            });
+            if let Some(keys) = test {
+                let additional = keys.iter().filter(|item| !generated_xpub_keys.contains(item));
+                additional.enumerate().for_each(|(idx, xpub)| {
+                    if idx == 0 {
+                        tprintln!(ctx, "additional xpubs: ");
+                    }
+                    tprintln!(ctx, "{}", ctx.wallet().network_format_xpub(xpub));
+                });
+            }
             Ok(())
         }
     }
@@ -93,6 +105,13 @@ async fn export_single_key_account(ctx: Arc<SpectreCli>, account: Arc<dyn Accoun
 
     let prv_key_data = keydata.payload.decrypt(payment_secret.as_ref())?;
     let mnemonic = prv_key_data.as_ref().as_mnemonic()?;
+
+    let xpub_key = keydata.create_xpub(None, BIP32_ACCOUNT_KIND.into(), 0).await?; // todo it can be done concurrently
+
+    tprintln!(ctx, "extended public key:");
+    tprintln!(ctx, "");
+    tprintln!(ctx, "{}", ctx.wallet().network_format_xpub(&xpub_key));
+    tprintln!(ctx, "");
 
     match mnemonic {
         None => {

--- a/cli/src/modules/export.rs
+++ b/cli/src/modules/export.rs
@@ -2,7 +2,7 @@ use crate::imports::*;
 use spectre_wallet_core::account::{multisig::MultiSig, Account, BIP32_ACCOUNT_KIND, MULTISIG_ACCOUNT_KIND};
 
 #[derive(Default, Handler)]
-#[help("Export transactions, a wallet or a private key")]
+#[help("Export transactions, a wallet, a private key, or an extended public key (kpub)")]
 pub struct Export;
 
 impl Export {

--- a/cli/src/modules/export.rs
+++ b/cli/src/modules/export.rs
@@ -54,12 +54,12 @@ async fn export_multisig_account(ctx: Arc<SpectreCli>, account: Arc<MultiSig>) -
                     prv_key_data.create_xpub(None, MULTISIG_ACCOUNT_KIND.into(), 0).await?; // todo it can be done concurrently
 
                 tprintln!(ctx, "");
-                tprintln!(ctx, "extended public key {}:", id + 1);
+                tprintln!(ctx, "Extended public key {}:", id + 1);
                 tprintln!(ctx, "");
                 tprintln!(ctx, "{}", ctx.wallet().network_format_xpub(&xpub_key));
                 tprintln!(ctx, "");
 
-                tprintln!(ctx, "mnemonic {}:", id + 1);
+                tprintln!(ctx, "Mnemonic {}:", id + 1);
                 tprintln!(ctx, "");
                 tprintln!(ctx, "{}", mnemonic.phrase());
                 tprintln!(ctx, "");
@@ -108,7 +108,7 @@ async fn export_single_key_account(ctx: Arc<SpectreCli>, account: Arc<dyn Accoun
 
     let xpub_key = keydata.create_xpub(None, BIP32_ACCOUNT_KIND.into(), 0).await?; // todo it can be done concurrently
 
-    tprintln!(ctx, "extended public key:");
+    tprintln!(ctx, "Extended public key:");
     tprintln!(ctx, "");
     tprintln!(ctx, "{}", ctx.wallet().network_format_xpub(&xpub_key));
     tprintln!(ctx, "");

--- a/cli/src/wizards/account.rs
+++ b/cli/src/wizards/account.rs
@@ -85,3 +85,62 @@ async fn create_multisig(ctx: &Arc<SpectreCli>, account_name: Option<String>, mn
     wallet.select(Some(&account)).await?;
     Ok(())
 }
+
+pub(crate) async fn bip32_watch(ctx: &Arc<SpectreCli>, name: Option<&str>) -> Result<()> {
+    let term = ctx.term();
+    let wallet = ctx.wallet();
+
+    let name = if let Some(name) = name {
+        Some(name.to_string())
+    } else {
+        Some(term.ask(false, "Please enter account name (optional, press <enter> to skip): ").await?.trim().to_string())
+    };
+
+    let mut xpub_keys = Vec::with_capacity(1);
+    let xpub_key = term.ask(false, "Enter extended public key: ").await?;
+    xpub_keys.push(xpub_key.trim().to_owned());
+
+    let wallet_secret = Secret::new(term.ask(true, "Enter wallet password: ").await?.trim().as_bytes().to_vec());
+    if wallet_secret.as_ref().is_empty() {
+        return Err(Error::WalletSecretRequired);
+    }
+
+    let account_create_args_bip32_watch = AccountCreateArgsBip32Watch::new(name, xpub_keys);
+    let account = wallet.create_account_bip32_watch(&wallet_secret, account_create_args_bip32_watch).await?;
+
+    tprintln!(ctx, "\naccount created: {}\n", account.get_list_string()?);
+    wallet.select(Some(&account)).await?;
+    Ok(())
+}
+
+pub(crate) async fn multisig_watch(ctx: &Arc<SpectreCli>, name: Option<&str>) -> Result<()> {
+    let term = ctx.term();
+
+    let account_name = if let Some(name) = name {
+        Some(name.to_string())
+    } else {
+        Some(term.ask(false, "Please enter account name (optional, press <enter> to skip): ").await?.trim().to_string())
+    };
+
+    let term = ctx.term();
+    let wallet = ctx.wallet();
+    let (wallet_secret, _) = ctx.ask_wallet_secret(None).await?;
+    let minimum_signatures: u16 = term.ask(false, "Enter the minimum number of signatures required: ").await?.parse()?;
+
+    let prv_key_data_args = Vec::with_capacity(0);
+
+    let answer = term.ask(false, "Enter the number of extended public keys: ").await?.trim().to_string(); //.parse()?;
+    let xpub_keys_len: usize = if answer.is_empty() { 0 } else { answer.parse()? };
+
+    let mut xpub_keys = Vec::with_capacity(xpub_keys_len);
+    for i in 1..=xpub_keys_len {
+        let xpub_key = term.ask(false, &format!("Enter extended public {i} key: ")).await?;
+        xpub_keys.push(xpub_key.trim().to_owned());
+    }
+    let account =
+        wallet.create_account_multisig(&wallet_secret, prv_key_data_args, xpub_keys, account_name, minimum_signatures).await?;
+
+    tprintln!(ctx, "\naccount created: {}\n", account.get_list_string()?);
+    wallet.select(Some(&account)).await?;
+    Ok(())
+}

--- a/wallet/bip32/Cargo.toml
+++ b/wallet/bip32/Cargo.toml
@@ -31,6 +31,7 @@ thiserror.workspace = true
 wasm-bindgen.workspace = true
 workflow-wasm.workspace = true
 zeroize.workspace = true
+spectre-consensus-core.workspace = true
 
 [dev-dependencies]
 faster-hex.workspace = true

--- a/wallet/bip32/src/prefix.rs
+++ b/wallet/bip32/src/prefix.rs
@@ -6,6 +6,7 @@ use core::{
     fmt::{self, Debug, Display},
     str,
 };
+use spectre_consensus_core::network::{NetworkId, NetworkType};
 
 /// BIP32 extended key prefixes a.k.a. "versions" (e.g. `xpub`, `xprv`)
 ///
@@ -230,6 +231,18 @@ impl TryFrom<&str> for Prefix {
             "zprv" => Ok(Prefix::ZPRV),
             "zpub" => Ok(Prefix::ZPUB),
             _ => Err(Error::String(format!("Invalid prefix: {value}"))),
+        }
+    }
+}
+
+impl From<NetworkId> for Prefix {
+    fn from(value: NetworkId) -> Self {
+        let network_type = value.network_type();
+        match network_type {
+            NetworkType::Mainnet => Prefix::KPUB,
+            NetworkType::Devnet => Prefix::KTUB,
+            NetworkType::Simnet => Prefix::KTUB,
+            NetworkType::Testnet => Prefix::KTUB,
         }
     }
 }

--- a/wallet/core/src/account/kind.rs
+++ b/wallet/core/src/account/kind.rs
@@ -66,6 +66,7 @@ impl FromStr for AccountKind {
                 "bip32" => Ok(BIP32_ACCOUNT_KIND.into()),
                 "multisig" => Ok(MULTISIG_ACCOUNT_KIND.into()),
                 "keypair" => Ok(KEYPAIR_ACCOUNT_KIND.into()),
+                "bip32watch" => Ok(BIP32_WATCH_ACCOUNT_KIND.into()),
                 _ => Err(Error::InvalidAccountKind),
             }
         }

--- a/wallet/core/src/account/mod.rs
+++ b/wallet/core/src/account/mod.rs
@@ -116,6 +116,14 @@ pub trait Account: AnySync + Send + Sync + 'static {
         self.context().settings.name.clone()
     }
 
+    fn feature(&self) -> Option<String> {
+        None
+    }
+
+    fn xpub_keys(&self) -> Option<&ExtendedPublicKeys> {
+        None
+    }
+
     fn name_or_id(&self) -> String {
         if let Some(name) = self.name() {
             if name.is_empty() {

--- a/wallet/core/src/account/variants/bip32.rs
+++ b/wallet/core/src/account/variants/bip32.rs
@@ -169,6 +169,10 @@ impl Account for Bip32 {
         BIP32_ACCOUNT_KIND.into()
     }
 
+    // fn xpub_keys(&self) -> Option<&ExtendedPublicKeys> {
+    //     None
+    // }
+
     fn prv_key_data_id(&self) -> Result<&PrvKeyDataId> {
         Ok(&self.prv_key_data_id)
     }

--- a/wallet/core/src/account/variants/bip32watch.rs
+++ b/wallet/core/src/account/variants/bip32watch.rs
@@ -1,23 +1,23 @@
 //!
-//! MultiSig account implementation.
+//! bip32-watch account implementation
 //!
 
 use crate::account::Inner;
 use crate::derivation::{AddressDerivationManager, AddressDerivationManagerTrait};
 use crate::imports::*;
 
-pub const MULTISIG_ACCOUNT_KIND: &str = "spectre-multisig-standard";
+pub const BIP32_WATCH_ACCOUNT_KIND: &str = "spectre-bip32-watch-standard";
 
 pub struct Ctor {}
 
 #[async_trait]
 impl Factory for Ctor {
     fn name(&self) -> String {
-        "multisig".to_string()
+        "bip32watch".to_string()
     }
 
     fn description(&self) -> String {
-        "Spectre Core Multi-Signature Account".to_string()
+        "Spectre Core bip32-watch Account".to_string()
     }
 
     async fn try_load(
@@ -26,7 +26,7 @@ impl Factory for Ctor {
         storage: &AccountStorage,
         meta: Option<Arc<AccountMetadata>>,
     ) -> Result<Arc<dyn Account>> {
-        Ok(Arc::new(MultiSig::try_load(wallet, storage, meta).await?))
+        Ok(Arc::new(bip32watch::Bip32Watch::try_load(wallet, storage, meta).await?))
     }
 }
 
@@ -34,14 +34,12 @@ impl Factory for Ctor {
 #[serde(rename_all = "lowercase")]
 pub struct Payload {
     pub xpub_keys: ExtendedPublicKeys,
-    pub cosigner_index: Option<u8>,
-    pub minimum_signatures: u16,
     pub ecdsa: bool,
 }
 
 impl Payload {
-    pub fn new(xpub_keys: ExtendedPublicKeys, cosigner_index: Option<u8>, minimum_signatures: u16, ecdsa: bool) -> Self {
-        Self { xpub_keys, cosigner_index, minimum_signatures, ecdsa }
+    pub fn new(xpub_keys: Arc<Vec<ExtendedPublicKeySecp256k1>>, ecdsa: bool) -> Self {
+        Self { xpub_keys, ecdsa }
     }
 
     pub fn try_load(storage: &AccountStorage) -> Result<Self> {
@@ -50,7 +48,10 @@ impl Payload {
 }
 
 impl Storable for Payload {
-    const STORAGE_MAGIC: u32 = 0x4749534d;
+    // a unique number used for binary
+    // serialization data alignment check
+    const STORAGE_MAGIC: u32 = 0x92014137;
+    // binary serialization version
     const STORAGE_VERSION: u32 = 0;
 }
 
@@ -59,10 +60,7 @@ impl AccountStorable for Payload {}
 impl BorshSerialize for Payload {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         StorageHeader::new(Self::STORAGE_MAGIC, Self::STORAGE_VERSION).serialize(writer)?;
-
         BorshSerialize::serialize(&self.xpub_keys, writer)?;
-        BorshSerialize::serialize(&self.cosigner_index, writer)?;
-        BorshSerialize::serialize(&self.minimum_signatures, writer)?;
         BorshSerialize::serialize(&self.ecdsa, writer)?;
 
         Ok(())
@@ -75,108 +73,81 @@ impl BorshDeserialize for Payload {
             StorageHeader::deserialize(buf)?.try_magic(Self::STORAGE_MAGIC)?.try_version(Self::STORAGE_VERSION)?;
 
         let xpub_keys = BorshDeserialize::deserialize(buf)?;
-        let cosigner_index = BorshDeserialize::deserialize(buf)?;
-        let minimum_signatures = BorshDeserialize::deserialize(buf)?;
         let ecdsa = BorshDeserialize::deserialize(buf)?;
 
-        Ok(Self { xpub_keys, cosigner_index, minimum_signatures, ecdsa })
+        Ok(Self { xpub_keys, ecdsa })
     }
 }
 
-pub struct MultiSig {
+pub struct Bip32Watch {
     inner: Arc<Inner>,
     xpub_keys: ExtendedPublicKeys,
-    prv_key_data_ids: Option<Arc<Vec<PrvKeyDataId>>>,
-    cosigner_index: Option<u8>,
-    minimum_signatures: u16,
     ecdsa: bool,
     derivation: Arc<AddressDerivationManager>,
 }
 
-impl MultiSig {
-    pub async fn try_new(
-        wallet: &Arc<Wallet>,
-        name: Option<String>,
-        xpub_keys: ExtendedPublicKeys,
-        prv_key_data_ids: Option<Arc<Vec<PrvKeyDataId>>>,
-        cosigner_index: Option<u8>,
-        minimum_signatures: u16,
-        ecdsa: bool,
-    ) -> Result<Self> {
-        let storable = Payload::new(xpub_keys.clone(), cosigner_index, minimum_signatures, ecdsa);
+impl Bip32Watch {
+    pub async fn try_new(wallet: &Arc<Wallet>, name: Option<String>, xpub_keys: ExtendedPublicKeys, ecdsa: bool) -> Result<Self> {
         let settings = AccountSettings { name, ..Default::default() };
-        let (id, storage_key) = make_account_hashes(from_multisig(&prv_key_data_ids, &storable));
+
+        let public_key = xpub_keys.first().ok_or_else(|| Error::Bip32WatchXpubRequired)?.public_key();
+
+        let (id, storage_key) = make_account_hashes(from_bip32_watch(public_key));
+
         let inner = Arc::new(Inner::new(wallet, id, storage_key, settings));
 
-        let derivation = AddressDerivationManager::new(
-            wallet,
-            MULTISIG_ACCOUNT_KIND.into(),
-            &xpub_keys,
-            ecdsa,
-            0,
-            cosigner_index.map(|v| v as u32),
-            minimum_signatures,
-            Default::default(),
-        )
-        .await?;
+        let derivation =
+            AddressDerivationManager::new(wallet, BIP32_WATCH_ACCOUNT_KIND.into(), &xpub_keys, ecdsa, 0, None, 1, Default::default())
+                .await?;
 
-        Ok(Self { inner, xpub_keys, cosigner_index, minimum_signatures, ecdsa, derivation, prv_key_data_ids })
+        Ok(Self { inner, xpub_keys, ecdsa, derivation })
     }
 
     pub async fn try_load(wallet: &Arc<Wallet>, storage: &AccountStorage, meta: Option<Arc<AccountMetadata>>) -> Result<Self> {
         let storable = Payload::try_load(storage)?;
         let inner = Arc::new(Inner::from_storage(wallet, storage));
-
-        let Payload { xpub_keys, cosigner_index, minimum_signatures, ecdsa, .. } = storable;
-
+        let Payload { xpub_keys, ecdsa, .. } = storable;
         let address_derivation_indexes = meta.and_then(|meta| meta.address_derivation_indexes()).unwrap_or_default();
 
         let derivation = AddressDerivationManager::new(
             wallet,
-            MULTISIG_ACCOUNT_KIND.into(),
+            BIP32_WATCH_ACCOUNT_KIND.into(),
             &xpub_keys,
             ecdsa,
             0,
-            cosigner_index.map(|v| v as u32),
-            minimum_signatures,
+            None,
+            1,
             address_derivation_indexes,
         )
         .await?;
 
-        // TODO @maxim check variants transforms - None->Ok(None), Multiple->Ok(Some()), Single->Err()
-        let prv_key_data_ids = storage.prv_key_data_ids.clone().try_into()?;
-
-        Ok(Self { inner, xpub_keys, cosigner_index, minimum_signatures, ecdsa, derivation, prv_key_data_ids })
+        Ok(Self { inner, xpub_keys, ecdsa, derivation })
     }
 
-    pub fn prv_key_data_ids(&self) -> &Option<Arc<Vec<PrvKeyDataId>>> {
-        &self.prv_key_data_ids
+    pub fn get_address_range_for_scan(&self, range: std::ops::Range<u32>) -> Result<Vec<Address>> {
+        let receive_addresses = self.derivation.receive_address_manager().get_range_with_args(range.clone(), false)?;
+        let change_addresses = self.derivation.change_address_manager().get_range_with_args(range, false)?;
+        Ok(receive_addresses.into_iter().chain(change_addresses).collect::<Vec<_>>())
     }
 
-    pub fn minimum_signatures(&self) -> u16 {
-        self.minimum_signatures
-    }
-
-    fn watch_only(&self) -> bool {
-        self.prv_key_data_ids.is_none()
-    }
+    // pub fn xpub_keys(&self) -> &ExtendedPublicKeys {
+    //     &self.xpub_keys
+    // }
 }
 
 #[async_trait]
-impl Account for MultiSig {
+impl Account for Bip32Watch {
     fn inner(&self) -> &Arc<Inner> {
         &self.inner
     }
 
     fn account_kind(&self) -> AccountKind {
-        MULTISIG_ACCOUNT_KIND.into()
+        BIP32_WATCH_ACCOUNT_KIND.into()
     }
 
     fn feature(&self) -> Option<String> {
-        match self.watch_only() {
-            true => Some("multisig-watch".to_string()),
-            false => None,
-        }
+        let info = "bip32-watch";
+        Some(info.into())
     }
 
     fn xpub_keys(&self) -> Option<&ExtendedPublicKeys> {
@@ -184,7 +155,7 @@ impl Account for MultiSig {
     }
 
     fn prv_key_data_id(&self) -> Result<&PrvKeyDataId> {
-        Err(Error::AccountKindFeature)
+        Err(Error::Bip32WatchAccount)
     }
 
     fn as_dyn_arc(self: Arc<Self>) -> Arc<dyn Account> {
@@ -196,30 +167,30 @@ impl Account for MultiSig {
     }
 
     fn minimum_signatures(&self) -> u16 {
-        self.minimum_signatures
+        1
     }
 
     fn receive_address(&self) -> Result<Address> {
         self.derivation.receive_address_manager().current_address()
     }
-
     fn change_address(&self) -> Result<Address> {
         self.derivation.change_address_manager().current_address()
     }
 
     fn to_storage(&self) -> Result<AccountStorage> {
         let settings = self.context().settings.clone();
-        let storable = Payload::new(self.xpub_keys.clone(), self.cosigner_index, self.minimum_signatures, self.ecdsa);
-        let account_storage = AccountStorage::try_new(
-            MULTISIG_ACCOUNT_KIND.into(),
+        let storable = Payload::new(self.xpub_keys.clone(), self.ecdsa);
+
+        let storage = AccountStorage::try_new(
+            BIP32_WATCH_ACCOUNT_KIND.into(),
             self.id(),
             self.storage_key(),
-            self.prv_key_data_ids.clone().try_into()?,
+            AssocPrvKeyDataIds::None,
             settings,
             storable,
         )?;
 
-        Ok(account_storage)
+        Ok(storage)
     }
 
     fn metadata(&self) -> Result<Option<AccountMetadata>> {
@@ -229,10 +200,10 @@ impl Account for MultiSig {
 
     fn descriptor(&self) -> Result<AccountDescriptor> {
         let descriptor = AccountDescriptor::new(
-            MULTISIG_ACCOUNT_KIND.into(),
+            BIP32_WATCH_ACCOUNT_KIND.into(),
             *self.id(),
             self.name(),
-            self.prv_key_data_ids.clone().try_into()?,
+            AssocPrvKeyDataIds::None,
             self.receive_address().ok(),
             self.change_address().ok(),
         )
@@ -248,7 +219,7 @@ impl Account for MultiSig {
     }
 }
 
-impl DerivationCapableAccount for MultiSig {
+impl DerivationCapableAccount for Bip32Watch {
     fn derivation(&self) -> Arc<dyn AddressDerivationManagerTrait> {
         self.derivation.clone()
     }
@@ -264,13 +235,11 @@ mod tests {
     use crate::tests::*;
 
     #[test]
-    fn test_storage_multisig() -> Result<()> {
-        let storable_in = Payload::new(vec![make_xpub()].into(), Some(42), 0xc0fe, false);
+    fn test_storage_bip32watch() -> Result<()> {
+        let storable_in = Payload::new(vec![make_xpub()].into(), false);
         let guard = StorageGuard::new(&storable_in);
         let storable_out = guard.validate()?;
 
-        assert_eq!(storable_in.cosigner_index, storable_out.cosigner_index);
-        assert_eq!(storable_in.minimum_signatures, storable_out.minimum_signatures);
         assert_eq!(storable_in.ecdsa, storable_out.ecdsa);
         assert_eq!(storable_in.xpub_keys.len(), storable_out.xpub_keys.len());
         for idx in 0..storable_in.xpub_keys.len() {

--- a/wallet/core/src/account/variants/mod.rs
+++ b/wallet/core/src/account/variants/mod.rs
@@ -3,12 +3,14 @@
 //!
 
 pub mod bip32;
+pub mod bip32watch;
 pub mod keypair;
 pub mod legacy;
 pub mod multisig;
 pub mod resident;
 
 pub use bip32::BIP32_ACCOUNT_KIND;
+pub use bip32watch::BIP32_WATCH_ACCOUNT_KIND;
 pub use keypair::KEYPAIR_ACCOUNT_KIND;
 pub use legacy::LEGACY_ACCOUNT_KIND;
 pub use multisig::MULTISIG_ACCOUNT_KIND;

--- a/wallet/core/src/account/variants/watchonly.rs
+++ b/wallet/core/src/account/variants/watchonly.rs
@@ -1,23 +1,23 @@
 //!
-//! MultiSig account implementation.
+//! Watch-only account implementation
 //!
 
 use crate::account::Inner;
 use crate::derivation::{AddressDerivationManager, AddressDerivationManagerTrait};
 use crate::imports::*;
 
-pub const MULTISIG_ACCOUNT_KIND: &str = "spectre-multisig-standard";
+pub const WATCH_ONLY_ACCOUNT_KIND: &str = "spectre-watch-only-standard";
 
 pub struct Ctor {}
 
 #[async_trait]
 impl Factory for Ctor {
     fn name(&self) -> String {
-        "multisig".to_string()
+        "watchonly".to_string()
     }
 
     fn description(&self) -> String {
-        "Spectre Core Multi-Signature Account".to_string()
+        "Spectre Core watch-only Account".to_string()
     }
 
     async fn try_load(
@@ -26,7 +26,7 @@ impl Factory for Ctor {
         storage: &AccountStorage,
         meta: Option<Arc<AccountMetadata>>,
     ) -> Result<Arc<dyn Account>> {
-        Ok(Arc::new(MultiSig::try_load(wallet, storage, meta).await?))
+        Ok(Arc::new(watchonly::WatchOnly::try_load(wallet, storage, meta).await?))
     }
 }
 
@@ -34,14 +34,13 @@ impl Factory for Ctor {
 #[serde(rename_all = "lowercase")]
 pub struct Payload {
     pub xpub_keys: ExtendedPublicKeys,
-    pub cosigner_index: Option<u8>,
     pub minimum_signatures: u16,
     pub ecdsa: bool,
 }
 
 impl Payload {
-    pub fn new(xpub_keys: ExtendedPublicKeys, cosigner_index: Option<u8>, minimum_signatures: u16, ecdsa: bool) -> Self {
-        Self { xpub_keys, cosigner_index, minimum_signatures, ecdsa }
+    pub fn new(xpub_keys: Arc<Vec<ExtendedPublicKeySecp256k1>>, minimum_signatures: u16, ecdsa: bool) -> Self {
+        Self { xpub_keys, minimum_signatures, ecdsa }
     }
 
     pub fn try_load(storage: &AccountStorage) -> Result<Self> {
@@ -50,7 +49,10 @@ impl Payload {
 }
 
 impl Storable for Payload {
-    const STORAGE_MAGIC: u32 = 0x4749534d;
+    // a unique number used for binary
+    // serialization data alignment check
+    const STORAGE_MAGIC: u32 = 0x92014137;
+    // binary serialization version
     const STORAGE_VERSION: u32 = 0;
 }
 
@@ -59,9 +61,7 @@ impl AccountStorable for Payload {}
 impl BorshSerialize for Payload {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         StorageHeader::new(Self::STORAGE_MAGIC, Self::STORAGE_VERSION).serialize(writer)?;
-
         BorshSerialize::serialize(&self.xpub_keys, writer)?;
-        BorshSerialize::serialize(&self.cosigner_index, writer)?;
         BorshSerialize::serialize(&self.minimum_signatures, writer)?;
         BorshSerialize::serialize(&self.ecdsa, writer)?;
 
@@ -75,116 +75,134 @@ impl BorshDeserialize for Payload {
             StorageHeader::deserialize(buf)?.try_magic(Self::STORAGE_MAGIC)?.try_version(Self::STORAGE_VERSION)?;
 
         let xpub_keys = BorshDeserialize::deserialize(buf)?;
-        let cosigner_index = BorshDeserialize::deserialize(buf)?;
         let minimum_signatures = BorshDeserialize::deserialize(buf)?;
         let ecdsa = BorshDeserialize::deserialize(buf)?;
 
-        Ok(Self { xpub_keys, cosigner_index, minimum_signatures, ecdsa })
+        Ok(Self { xpub_keys, minimum_signatures, ecdsa })
     }
 }
 
-pub struct MultiSig {
+pub struct WatchOnly {
     inner: Arc<Inner>,
     xpub_keys: ExtendedPublicKeys,
-    prv_key_data_ids: Option<Arc<Vec<PrvKeyDataId>>>,
-    cosigner_index: Option<u8>,
     minimum_signatures: u16,
     ecdsa: bool,
     derivation: Arc<AddressDerivationManager>,
 }
 
-impl MultiSig {
+impl WatchOnly {
     pub async fn try_new(
         wallet: &Arc<Wallet>,
         name: Option<String>,
         xpub_keys: ExtendedPublicKeys,
-        prv_key_data_ids: Option<Arc<Vec<PrvKeyDataId>>>,
-        cosigner_index: Option<u8>,
         minimum_signatures: u16,
         ecdsa: bool,
     ) -> Result<Self> {
-        let storable = Payload::new(xpub_keys.clone(), cosigner_index, minimum_signatures, ecdsa);
         let settings = AccountSettings { name, ..Default::default() };
-        let (id, storage_key) = make_account_hashes(from_multisig(&prv_key_data_ids, &storable));
+
+        let public_key = xpub_keys.first().ok_or_else(|| Error::WatchOnlyXpubRequired)?.public_key();
+
+        let storable = Payload::new(xpub_keys.clone(), minimum_signatures, ecdsa);
+
+        let (id, storage_key) = match xpub_keys.len() {
+            1 => make_account_hashes(from_watch_only(&public_key)),
+            _ => make_account_hashes(from_watch_only_multisig(&None, &storable)),
+        };
         let inner = Arc::new(Inner::new(wallet, id, storage_key, settings));
 
-        let derivation = AddressDerivationManager::new(
-            wallet,
-            MULTISIG_ACCOUNT_KIND.into(),
-            &xpub_keys,
-            ecdsa,
-            0,
-            cosigner_index.map(|v| v as u32),
-            minimum_signatures,
-            Default::default(),
-        )
-        .await?;
+        let derivation = match xpub_keys.len() {
+            1 => {
+                AddressDerivationManager::new(
+                    wallet,
+                    WATCH_ONLY_ACCOUNT_KIND.into(),
+                    &xpub_keys,
+                    ecdsa,
+                    0,
+                    None,
+                    1,
+                    Default::default(),
+                )
+                .await?
+            }
+            _ => {
+                AddressDerivationManager::new(
+                    wallet,
+                    MULTISIG_ACCOUNT_KIND.into(),
+                    &xpub_keys,
+                    ecdsa,
+                    0,
+                    Some(u32::MIN),
+                    minimum_signatures,
+                    Default::default(),
+                )
+                .await?
+            }
+        };
 
-        Ok(Self { inner, xpub_keys, cosigner_index, minimum_signatures, ecdsa, derivation, prv_key_data_ids })
+        Ok(Self { inner, xpub_keys, minimum_signatures, ecdsa, derivation })
     }
 
     pub async fn try_load(wallet: &Arc<Wallet>, storage: &AccountStorage, meta: Option<Arc<AccountMetadata>>) -> Result<Self> {
         let storable = Payload::try_load(storage)?;
         let inner = Arc::new(Inner::from_storage(wallet, storage));
-
-        let Payload { xpub_keys, cosigner_index, minimum_signatures, ecdsa, .. } = storable;
-
+        let Payload { xpub_keys, minimum_signatures, ecdsa, .. } = storable;
         let address_derivation_indexes = meta.and_then(|meta| meta.address_derivation_indexes()).unwrap_or_default();
 
-        let derivation = AddressDerivationManager::new(
-            wallet,
-            MULTISIG_ACCOUNT_KIND.into(),
-            &xpub_keys,
-            ecdsa,
-            0,
-            cosigner_index.map(|v| v as u32),
-            minimum_signatures,
-            address_derivation_indexes,
-        )
-        .await?;
+        let derivation = match xpub_keys.len() {
+            1 => {
+                AddressDerivationManager::new(
+                    wallet,
+                    WATCH_ONLY_ACCOUNT_KIND.into(),
+                    &xpub_keys,
+                    ecdsa,
+                    0,
+                    None,
+                    1,
+                    address_derivation_indexes,
+                )
+                .await?
+            }
+            _ => {
+                AddressDerivationManager::new(
+                    wallet,
+                    MULTISIG_ACCOUNT_KIND.into(),
+                    &xpub_keys,
+                    ecdsa,
+                    0,
+                    Some(u32::MIN),
+                    minimum_signatures,
+                    address_derivation_indexes,
+                )
+                .await?
+            }
+        };
 
-        // TODO @maxim check variants transforms - None->Ok(None), Multiple->Ok(Some()), Single->Err()
-        let prv_key_data_ids = storage.prv_key_data_ids.clone().try_into()?;
-
-        Ok(Self { inner, xpub_keys, cosigner_index, minimum_signatures, ecdsa, derivation, prv_key_data_ids })
+        Ok(Self { inner, xpub_keys, minimum_signatures, ecdsa, derivation })
     }
 
-    pub fn prv_key_data_ids(&self) -> &Option<Arc<Vec<PrvKeyDataId>>> {
-        &self.prv_key_data_ids
+    pub fn get_address_range_for_scan(&self, range: std::ops::Range<u32>) -> Result<Vec<Address>> {
+        let receive_addresses = self.derivation.receive_address_manager().get_range_with_args(range.clone(), false)?;
+        let change_addresses = self.derivation.change_address_manager().get_range_with_args(range, false)?;
+        Ok(receive_addresses.into_iter().chain(change_addresses).collect::<Vec<_>>())
     }
 
-    pub fn minimum_signatures(&self) -> u16 {
-        self.minimum_signatures
-    }
-
-    fn watch_only(&self) -> bool {
-        self.prv_key_data_ids.is_none()
+    pub fn xpub_keys(&self) -> &ExtendedPublicKeys {
+        &self.xpub_keys
     }
 }
 
 #[async_trait]
-impl Account for MultiSig {
+impl Account for WatchOnly {
     fn inner(&self) -> &Arc<Inner> {
         &self.inner
     }
 
     fn account_kind(&self) -> AccountKind {
-        MULTISIG_ACCOUNT_KIND.into()
-    }
-
-    fn feature(&self) -> Option<String> {
-        match self.watch_only() {
-            true => Some("multisig-watch".to_string()),
-            false => None,
-        }
-    }
-
-    fn xpub_keys(&self) -> Option<&ExtendedPublicKeys> {
-        Some(&self.xpub_keys)
+        WATCH_ONLY_ACCOUNT_KIND.into()
     }
 
     fn prv_key_data_id(&self) -> Result<&PrvKeyDataId> {
-        Err(Error::AccountKindFeature)
+        Err(Error::WatchOnlyAccount)
     }
 
     fn as_dyn_arc(self: Arc<Self>) -> Arc<dyn Account> {
@@ -202,24 +220,24 @@ impl Account for MultiSig {
     fn receive_address(&self) -> Result<Address> {
         self.derivation.receive_address_manager().current_address()
     }
-
     fn change_address(&self) -> Result<Address> {
         self.derivation.change_address_manager().current_address()
     }
 
     fn to_storage(&self) -> Result<AccountStorage> {
         let settings = self.context().settings.clone();
-        let storable = Payload::new(self.xpub_keys.clone(), self.cosigner_index, self.minimum_signatures, self.ecdsa);
-        let account_storage = AccountStorage::try_new(
-            MULTISIG_ACCOUNT_KIND.into(),
+        let storable = Payload::new(self.xpub_keys.clone(), self.minimum_signatures, self.ecdsa);
+
+        let storage = AccountStorage::try_new(
+            WATCH_ONLY_ACCOUNT_KIND.into(),
             self.id(),
             self.storage_key(),
-            self.prv_key_data_ids.clone().try_into()?,
+            AssocPrvKeyDataIds::None,
             settings,
             storable,
         )?;
 
-        Ok(account_storage)
+        Ok(storage)
     }
 
     fn metadata(&self) -> Result<Option<AccountMetadata>> {
@@ -229,10 +247,10 @@ impl Account for MultiSig {
 
     fn descriptor(&self) -> Result<AccountDescriptor> {
         let descriptor = AccountDescriptor::new(
-            MULTISIG_ACCOUNT_KIND.into(),
+            WATCH_ONLY_ACCOUNT_KIND.into(),
             *self.id(),
             self.name(),
-            self.prv_key_data_ids.clone().try_into()?,
+            AssocPrvKeyDataIds::None,
             self.receive_address().ok(),
             self.change_address().ok(),
         )
@@ -246,9 +264,10 @@ impl Account for MultiSig {
     fn as_derivation_capable(self: Arc<Self>) -> Result<Arc<dyn DerivationCapableAccount>> {
         Ok(self.clone())
     }
+
 }
 
-impl DerivationCapableAccount for MultiSig {
+impl DerivationCapableAccount for WatchOnly {
     fn derivation(&self) -> Arc<dyn AddressDerivationManagerTrait> {
         self.derivation.clone()
     }
@@ -264,12 +283,11 @@ mod tests {
     use crate::tests::*;
 
     #[test]
-    fn test_storage_multisig() -> Result<()> {
-        let storable_in = Payload::new(vec![make_xpub()].into(), Some(42), 0xc0fe, false);
+    fn test_storage_watchonly() -> Result<()> {
+        let storable_in = Payload::new(vec![make_xpub()].into(), 1, false);
         let guard = StorageGuard::new(&storable_in);
         let storable_out = guard.validate()?;
 
-        assert_eq!(storable_in.cosigner_index, storable_out.cosigner_index);
         assert_eq!(storable_in.minimum_signatures, storable_out.minimum_signatures);
         assert_eq!(storable_in.ecdsa, storable_out.ecdsa);
         assert_eq!(storable_in.xpub_keys.len(), storable_out.xpub_keys.len());

--- a/wallet/core/src/derivation.rs
+++ b/wallet/core/src/derivation.rs
@@ -204,7 +204,7 @@ impl AddressDerivationManager {
             let derivator: Arc<dyn WalletDerivationManagerTrait> = match account_kind.as_ref() {
                 LEGACY_ACCOUNT_KIND => Arc::new(WalletDerivationManagerV0::from_extended_public_key(xpub.clone(), cosigner_index)?),
                 MULTISIG_ACCOUNT_KIND => {
-                    let cosigner_index = cosigner_index.ok_or(Error::InvalidAccountKind)?;
+                    let cosigner_index = cosigner_index.unwrap_or(0);
                     Arc::new(WalletDerivationManager::from_extended_public_key(xpub.clone(), Some(cosigner_index))?)
                 }
                 _ => Arc::new(WalletDerivationManager::from_extended_public_key(xpub.clone(), cosigner_index)?),

--- a/wallet/core/src/deterministic.rs
+++ b/wallet/core/src/deterministic.rs
@@ -2,7 +2,7 @@
 //! Deterministic byte sequence generation (used by Account ids).
 //!
 
-pub use crate::account::{bip32, keypair, legacy, multisig};
+pub use crate::account::{bip32, bip32watch, keypair, legacy, multisig};
 use crate::encryption::sha256_hash;
 use crate::imports::*;
 use crate::storage::PrvKeyDataId;
@@ -148,6 +148,22 @@ pub fn from_multisig<const N: usize>(prv_key_data_ids: &Option<Arc<Vec<PrvKeyDat
     make_hashes(hashable)
 }
 
+/// Create deterministic hashes from bip32-watch multisig account data.
+pub fn from_bip32_watch_multisig<const N: usize>(
+    prv_key_data_ids: &Option<Arc<Vec<PrvKeyDataId>>>,
+    data: &bip32watch::Payload,
+) -> [Hash; N] {
+    let hashable = DeterministicHashData {
+        account_kind: &multisig::MULTISIG_ACCOUNT_KIND.into(),
+        prv_key_data_ids,
+        ecdsa: Some(data.ecdsa),
+        account_index: None,
+        secp256k1_public_key: None,
+        data: Some(data.xpub_keys.try_to_vec().unwrap()),
+    };
+    make_hashes(hashable)
+}
+
 /// Create deterministic hashes from keypair account data.
 pub(crate) fn from_keypair<const N: usize>(prv_key_data_id: &PrvKeyDataId, data: &keypair::Payload) -> [Hash; N] {
     let hashable = DeterministicHashData {
@@ -156,6 +172,19 @@ pub(crate) fn from_keypair<const N: usize>(prv_key_data_id: &PrvKeyDataId, data:
         ecdsa: Some(data.ecdsa),
         account_index: None,
         secp256k1_public_key: Some(data.public_key.serialize().to_vec()),
+        data: None,
+    };
+    make_hashes(hashable)
+}
+
+/// Create deterministic hashes from bip32-watch.
+pub fn from_bip32_watch<const N: usize>(public_key: &PublicKey) -> [Hash; N] {
+    let hashable: DeterministicHashData<[PrvKeyDataId; 0]> = DeterministicHashData {
+        account_kind: &bip32watch::BIP32_WATCH_ACCOUNT_KIND.into(),
+        prv_key_data_ids: &None,
+        ecdsa: None,
+        account_index: Some(0),
+        secp256k1_public_key: Some(public_key.serialize().to_vec()),
         data: None,
     };
     make_hashes(hashable)

--- a/wallet/core/src/error.rs
+++ b/wallet/core/src/error.rs
@@ -186,7 +186,7 @@ pub enum Error {
     #[error("{0}")]
     TryFromEnum(#[from] workflow_core::enums::TryFromError),
 
-    #[error("Account factory found for type: {0}")]
+    #[error("Account factory not found for type: {0}")]
     AccountFactoryNotFound(AccountKind),
 
     #[error("Account not found: {0}")]
@@ -230,6 +230,12 @@ pub enum Error {
 
     #[error("Not allowed on a resident account")]
     ResidentAccount,
+
+    #[error("Not allowed on an bip32-watch account")]
+    Bip32WatchAccount,
+
+    #[error("At least one xpub is required for a bip32-watch account")]
+    Bip32WatchXpubRequired,
 
     #[error("This feature is not supported by this account type")]
     AccountKindFeature,

--- a/wallet/core/src/factory.rs
+++ b/wallet/core/src/factory.rs
@@ -32,6 +32,7 @@ pub fn factories() -> &'static FactoryMap {
             (LEGACY_ACCOUNT_KIND.into(), Arc::new(legacy::Ctor {})),
             (MULTISIG_ACCOUNT_KIND.into(), Arc::new(multisig::Ctor {})),
             (KEYPAIR_ACCOUNT_KIND.into(), Arc::new(keypair::Ctor {})),
+            (BIP32_WATCH_ACCOUNT_KIND.into(), Arc::new(bip32watch::Ctor {})),
         ];
 
         let external = EXTERNAL.get_or_init(|| Mutex::new(AHashMap::new())).lock().unwrap().clone();

--- a/wallet/core/src/utxo/context.rs
+++ b/wallet/core/src/utxo/context.rs
@@ -346,7 +346,7 @@ impl UtxoContext {
                 } else {
                     remove_mature_ids.push(id);
                 }
-            } else {
+            } else if context.outgoing.get(&utxo.transaction_id()).is_none() {
                 log_error!("Error: UTXO not found in UtxoContext map!");
             }
         }
@@ -482,19 +482,25 @@ impl UtxoContext {
         // the final payments (not compound transactions)
         // and outgoing transactions that have not yet
         // been accepted
+        let mut outgoing_without_batch_tx = 0;
         let mut outgoing: u64 = 0;
         let mut consumed: u64 = 0;
-        for tx in context.outgoing.values() {
-            if !tx.is_accepted() {
-                if let Some(payment_value) = tx.payment_value() {
+
+        let transactions = context.outgoing.values().filter(|tx| !tx.is_accepted());
+        for tx in transactions {
+            if let Some(payment_value) = tx.payment_value() {
+                consumed += tx.aggregate_input_value();
+                if tx.is_batch() {
+                    outgoing += tx.fees() + tx.aggregate_output_value();
+                } else {
                     // final tx
                     outgoing += tx.fees() + payment_value;
-                    consumed += tx.aggregate_input_value();
-                } else {
-                    // compound tx has no payment value
-                    outgoing += tx.fees() + tx.aggregate_output_value();
-                    consumed += tx.aggregate_input_value()
+                    outgoing_without_batch_tx += payment_value;
                 }
+            } else {
+                // compound tx has no payment value
+                outgoing += tx.fees() + tx.aggregate_output_value();
+                consumed += tx.aggregate_input_value();
             }
         }
 
@@ -502,13 +508,13 @@ impl UtxoContext {
         // this condition does not occur. This is a temporary
         // log for a fixed bug, but we want to keep the check
         // just in case.
-        if mature + consumed < outgoing {
-            log_error!("Error: outgoing transaction value exceeds available balance");
+        if consumed < outgoing {
+            log_error!("Error: outgoing transaction value exceeds available balance, mature: {mature}, consumed: {consumed}, outgoing: {outgoing}");
         }
 
         let mature = (mature + consumed).saturating_sub(outgoing);
 
-        Balance::new(mature, pending, outgoing, context.mature.len(), context.pending.len(), context.stasis.len())
+        Balance::new(mature, pending, outgoing_without_batch_tx, context.mature.len(), context.pending.len(), context.stasis.len())
     }
 
     pub(crate) async fn handle_utxo_added(&self, utxos: Vec<UtxoEntryReference>, current_daa_score: u64) -> Result<()> {
@@ -527,12 +533,14 @@ impl UtxoContext {
             let force_maturity_if_outgoing = outgoing_transaction.is_some();
             let is_coinbase_stasis =
                 utxos.first().map(|utxo| matches!(utxo.maturity(&params, current_daa_score), Maturity::Stasis)).unwrap_or_default();
-
-            for utxo in utxos.iter() {
-                if let Err(err) = self.insert(utxo.clone(), current_daa_score, force_maturity_if_outgoing).await {
-                    // TODO - remove `Result<>` from insert at a later date once
-                    // we are confident that the insert will never result in an error.
-                    log_error!("{}", err);
+            let is_batch = outgoing_transaction.as_ref().map_or_else(|| false, |tx| tx.is_batch());
+            if !is_batch {
+                for utxo in utxos.iter() {
+                    if let Err(err) = self.insert(utxo.clone(), current_daa_score, force_maturity_if_outgoing).await {
+                        // TODO - remove `Result<>` from insert at a later date once
+                        // we are confident that the insert will never result in an error.
+                        log_error!("{}", err);
+                    }
                 }
             }
 
@@ -568,7 +576,6 @@ impl UtxoContext {
         // remove UTXOs from account set
 
         let outgoing_transactions = self.processor().outgoing();
-        #[allow(clippy::mutable_key_type)]
         let mut accepted_outgoing_transactions = HashSet::<OutgoingTransaction>::new();
 
         utxos.retain(|utxo| {

--- a/wallet/core/src/utxo/context.rs
+++ b/wallet/core/src/utxo/context.rs
@@ -576,6 +576,7 @@ impl UtxoContext {
         // remove UTXOs from account set
 
         let outgoing_transactions = self.processor().outgoing();
+        #[allow(clippy::mutable_key_type)]
         let mut accepted_outgoing_transactions = HashSet::<OutgoingTransaction>::new();
 
         utxos.retain(|utxo| {

--- a/wallet/core/src/wallet/args.rs
+++ b/wallet/core/src/wallet/args.rs
@@ -114,6 +114,18 @@ impl AccountCreateArgsBip32 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct AccountCreateArgsBip32Watch {
+    pub account_name: Option<String>,
+    pub xpub_keys: Vec<String>,
+}
+
+impl AccountCreateArgsBip32Watch {
+    pub fn new(account_name: Option<String>, xpub_keys: Vec<String>) -> Self {
+        Self { account_name, xpub_keys }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct PrvKeyDataArgs {
     pub prv_key_data_id: PrvKeyDataId,
     pub payment_secret: Option<Secret>,
@@ -141,6 +153,9 @@ pub enum AccountCreateArgs {
         additional_xpub_keys: Vec<String>,
         name: Option<String>,
         minimum_signatures: u16,
+    },
+    Bip32Watch {
+        account_args: AccountCreateArgsBip32Watch,
     },
 }
 

--- a/wallet/core/src/wallet/mod.rs
+++ b/wallet/core/src/wallet/mod.rs
@@ -21,6 +21,7 @@ use spectre_notify::{
     listener::ListenerId,
     scope::{Scope, VirtualDaaScoreChangedScope},
 };
+use spectre_wallet_keys::xpub::NetworkTaggedXpub;
 use spectre_wrpc_client::{Resolver, SpectreRpcClient, WrpcEncoding};
 use workflow_core::task::spawn;
 
@@ -621,6 +622,7 @@ impl Wallet {
             AccountCreateArgs::Multisig { prv_key_data_args, additional_xpub_keys, name, minimum_signatures } => {
                 self.create_account_multisig(wallet_secret, prv_key_data_args, additional_xpub_keys, name, minimum_signatures).await?
             }
+            AccountCreateArgs::Bip32Watch { account_args } => self.create_account_bip32_watch(wallet_secret, account_args).await?,
         };
 
         if notify {
@@ -737,6 +739,36 @@ impl Wallet {
 
         let account: Arc<dyn Account> =
             Arc::new(bip32::Bip32::try_new(self, account_name, prv_key_data.id, account_index, xpub_keys, false).await?);
+
+        if account_store.load_single(account.id()).await?.is_some() {
+            return Err(Error::AccountAlreadyExists(*account.id()));
+        }
+
+        self.inner.store.clone().as_account_store()?.store_single(&account.to_storage()?, None).await?;
+        self.inner.store.commit(wallet_secret).await?;
+
+        Ok(account)
+    }
+
+    pub async fn create_account_bip32_watch(
+        self: &Arc<Wallet>,
+        wallet_secret: &Secret,
+        account_args: AccountCreateArgsBip32Watch,
+    ) -> Result<Arc<dyn Account>> {
+        let account_store = self.inner.store.clone().as_account_store()?;
+
+        let AccountCreateArgsBip32Watch { account_name, xpub_keys } = account_args;
+
+        let xpub_keys = Arc::new(
+            xpub_keys
+                .into_iter()
+                .map(|xpub_key| {
+                    ExtendedPublicKeySecp256k1::from_str(&xpub_key).map_err(|err| Error::InvalidExtendedPublicKey(xpub_key, err))
+                })
+                .collect::<Result<Vec<_>>>()?,
+        );
+
+        let account: Arc<dyn Account> = Arc::new(bip32watch::Bip32Watch::try_new(self, account_name, xpub_keys, false).await?);
 
         if account_store.load_single(account.id()).await?.is_some() {
             return Err(Error::AccountAlreadyExists(*account.id()));
@@ -1593,6 +1625,10 @@ impl Wallet {
 
             Ok(account.descriptor()?)
         }
+    }
+
+    pub fn network_format_xpub(&self, xpub_key: &ExtendedPublicKeySecp256k1) -> String {
+        NetworkTaggedXpub::from((xpub_key.clone(), self.network_id().unwrap())).to_string()
     }
 }
 

--- a/wallet/keys/src/imports.rs
+++ b/wallet/keys/src/imports.rs
@@ -16,7 +16,7 @@ pub use js_sys::Array;
 pub use serde::{Deserialize, Serialize};
 pub use spectre_addresses::{Address, Version as AddressVersion};
 pub use spectre_bip32::{ChildNumber, ExtendedPrivateKey, ExtendedPublicKey, SecretKey};
-pub use spectre_consensus_core::network::NetworkTypeT;
+pub use spectre_consensus_core::network::{NetworkId, NetworkTypeT};
 pub use spectre_utils::hex::*;
 pub use spectre_wasm_core::types::*;
 pub use std::collections::HashMap;

--- a/wallet/keys/src/xpub.rs
+++ b/wallet/keys/src/xpub.rs
@@ -1,3 +1,6 @@
+use spectre_bip32::Prefix;
+use std::{fmt, str::FromStr};
+
 use crate::imports::*;
 
 ///
@@ -79,5 +82,28 @@ impl TryCastFromJs for XPub {
                 Err(Error::InvalidXPub)
             }
         })
+    }
+}
+
+pub struct NetworkTaggedXpub {
+    pub xpub: ExtendedPublicKey<secp256k1::PublicKey>,
+    pub network_id: NetworkId,
+}
+// impl NetworkTaggedXpub {
+
+// }
+
+impl fmt::Display for NetworkTaggedXpub {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let obj: XPub = self.xpub.clone().into();
+        write!(f, "{}", obj.inner.to_string(Some(Prefix::from(self.network_id))))
+    }
+}
+
+type TaggedXpub = (ExtendedPublicKey<secp256k1::PublicKey>, NetworkId);
+
+impl From<TaggedXpub> for NetworkTaggedXpub {
+    fn from(value: TaggedXpub) -> Self {
+        Self { xpub: value.0, network_id: value.1 }
     }
 }


### PR DESCRIPTION
The new watch-only account type now supports:

- BIP32
- Multisig

Updates include:

- The `export mnemonic` command now prints the extended public key, similar to the Golang spectrewallet
- `list` function now includes watch-only and xpub text hints to show the account type