### PR TITLE
TN and TN11 DNS seeders

### DIFF
--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -346,7 +346,11 @@ pub const MAINNET_PARAMS: Params = Params {
 };
 
 pub const TESTNET_PARAMS: Params = Params {
-    dns_seeders: &[],
+    dns_seeders: &[
+        // Official DNS seeders.
+        "testnet-dnsseed-1.spectre-network.org",
+        "testnet-dnsseed-2.spectre-network.org",
+    ],
     net: NetworkId::with_suffix(NetworkType::Testnet, 10),
     genesis: TESTNET_GENESIS,
     ghostdag_k: LEGACY_DEFAULT_GHOSTDAG_K,
@@ -400,7 +404,11 @@ pub const TESTNET_PARAMS: Params = Params {
 };
 
 pub const TESTNET11_PARAMS: Params = Params {
-    dns_seeders: &[],
+    dns_seeders: &[
+        // Official DNS seeders.
+        "testnet11-dnsseed-1.spectre-network.org",
+        "testnet11-dnsseed-2.spectre-network.org",
+    ],
     net: NetworkId::with_suffix(NetworkType::Testnet, 11),
     genesis: TESTNET11_GENESIS,
     legacy_timestamp_deviation_tolerance: LEGACY_TIMESTAMP_DEVIATION_TOLERANCE,


### PR DESCRIPTION
* Added official testnet DNS seeders `testnet-dnsseed-1.spectre-network.org` and `testnet-dnsseed-2.spectre-network.org`.
* Added official testnet11 (10bps) DNS seeders `testnet11-dnsseed-1.spectre-network.org` and `testnet11-dnsseed-2.spectre-network.org`.