### PR TITLE
Enforce zig 0.13.0 as newer version breaks the build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,6 +347,8 @@ jobs:
       - name: Install zig
         if: runner.os == 'Linux'
         uses: goto-bus-stop/setup-zig@v2 # needed for cargo-zigbuild
+        with:
+          version: 0.13.0
 
       - name: Build on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,6 +58,8 @@ jobs:
       - name: Install zig on Linux
         if: runner.os == 'Linux'
         uses: goto-bus-stop/setup-zig@v2 # needed for cargo-zigbuild
+        with:
+          version: 0.13.0
 
       - name: Install protoc on Linux
         if: runner.os == 'Linux'


### PR DESCRIPTION
Latest zig 0.14.0 release from 2024-10-25 breaks compilation of the `musl` targets. Lets enforce specific zig version which works for now.