### PR TITLE
feat: `--send-all` option v2

### DIFF
--- a/cli/src/modules/guide.txt
+++ b/cli/src/modules/guide.txt
@@ -1,10 +1,10 @@
-Before you start, you must configure the default network setting.  There are currently
-3 networks available.  `mainnet`, `testnet-10` and `testnet-11`.  If you wish to experiment,
-you should select `testnet-11` by entering `network testnet-11`
+Before you start, you must configure the default network setting. There are currently
+3 networks available: `mainnet`, `testnet-10`, and `testnet-11`. If you wish to experiment,
+you should select `testnet-11` by entering `network testnet-11`.
 
-The `server` command configures the target server.  You can connect to any Rusty Spectre
+The `server` command configures the target server. You can connect to any Rusty Spectre
 node that has wRPC enabled with `--rpclisten-borsh=0.0.0.0`. If the server setting 
-is set to 'public' the node will connect to the public node infrastructure.
+is set to 'public', the node will connect to the public node infrastructure.
 
 Both network and server values are stored in the application settings and are 
 used when running a local node or connecting to a remote node.
@@ -13,33 +13,33 @@ used when running a local node or connecting to a remote node.
 
 `wallet create [<name>]` Use this command to create a local wallet. The <name> argument 
 is optional (the default wallet name is "spectre") and allows you to create multiple 
-named wallets.  Only one wallet can be opened at a time. Keep in mind that a wallet can have multiple
-accounts, as such you only need one wallet, unless, for example, you want to separate wallets for 
+named wallets. Only one wallet can be opened at a time. Keep in mind that a wallet can have multiple
+accounts, as such you only need one wallet unless, for example, you want to separate wallets for 
 personal and business needs (but you can also create isolated accounts within a wallet).
 
-Make sure to record your mnemonic, even if working with a testnet, not to lose your
+Make sure to record your mnemonic, even if working with a testnet, so as not to lose your
 testnet SPR.
 
-`open <name>` - opens the wallet (the wallet is open automatically after creation).
+`open <name>` - Opens the wallet (the wallet is open automatically after creation).
 
 `list` - Lists all wallet accounts and their balances.
 
-`select <account-name>` - Selects an active account. The <account-name> can be the first few letters of the name or id of the account.
+`select <account-name>` - Selects an active account. The <account-name> can be the first few letters of the name or ID of the account.
 
 `account create bip32 [<name>]` - Allows you to create additional HD wallet accounts linked to the default private key of your wallet.
 
-`address` - shows your selected account address
+`address` - Shows your selected account address.
 
 Before you transact: `mute` option (enabled by default) toggles mute on/off. Mute enables terminal
-output of internal framework events.  Rust and JavaScript/TypeScript applications integrating with this platform 
+output of internal framework events. Rust and JavaScript/TypeScript applications integrating with this platform
 are meant to update their state by monitoring event notifications. Mute allows you to see these events in
-the terminal.  When mute is off, all events are displayed in the terminal.  When mute is on, you can use 'track'
-command to enable specific event notification.
+the terminal. When mute is off, all events are displayed in the terminal. When mute is on, you can use the 'track'
+command to enable specific event notifications.
 
-`transfer <account-name> <amount>` - Transfers from the active to a different account. For example 'transfer p 1' will transfer 1 SPR from
-the selected account to an account named 'pete' (starts with a 'p' letter)
+`transfer <account-name> <amount>` - Transfers from the active to a different account. For example, 'transfer p 1' will transfer 1 SPR from
+the selected account to an account named 'pete' (starts with a 'p' letter).
 
-`send <address> <amount>` - Send funds to a destination address .
+`send <address> <amount>` - Sends funds to a destination address.
 
 `estimate <amount>` - Provides a fee and UTXO consumption estimate for a transaction of a given amount.
 
@@ -47,9 +47,8 @@ the selected account to an account named 'pete' (starts with a 'p' letter)
 
 `history list` - Shows previous account transactions.
 
-`history details` - Show previous account transactions with extended information.
+`history details` - Shows previous account transactions with extended information.
 
 `monitor` - A test screen environment that periodically updates account balances.
 
-`rpc` - Allows you to execute RPC methods against the node (not all methods are currently available)
-
+`rpc` - Allows you to execute RPC methods against the node (not all methods are currently available).

--- a/cli/src/modules/guide.txt
+++ b/cli/src/modules/guide.txt
@@ -41,6 +41,8 @@ the selected account to an account named 'pete' (starts with a 'p' letter).
 
 `send <address> <amount>` - Sends funds to a destination address.
 
+`send <address> --send-all` - Sends all available funds to a destination address.
+
 `estimate <amount>` - Provides a fee and UTXO consumption estimate for a transaction of a given amount.
 
 `sweep` - Sweeps account UTXOs to reduce the UTXO size.

--- a/cli/src/modules/send.rs
+++ b/cli/src/modules/send.rs
@@ -12,15 +12,45 @@ impl Send {
         let account = ctx.wallet().account()?;
 
         if argv.len() < 2 {
-            tprintln!(ctx, "Usage: send <address> <amount> <priority fee>");
+            tprintln!(ctx, "Usage: send <address> <amount|--send-all> <priority fee>");
             return Ok(());
         }
 
         let address = Address::try_from(argv.first().unwrap().as_str())?;
-        let amount_sompi = try_parse_required_nonzero_spectre_as_sompi_u64(argv.get(1))?;
-        let priority_fee_sompi = try_parse_optional_spectre_as_sompi_i64(argv.get(2))?.unwrap_or(0);
-        let outputs = PaymentOutputs::from((address.clone(), amount_sompi));
         let abortable = Abortable::default();
+
+        // get priority fee first.
+        let priority_fee_sompi = try_parse_optional_spectre_as_sompi_i64(argv.get(2))?.unwrap_or(0);
+
+        // handle --send-all
+        let amount_sompi = if argv.get(1).unwrap() == "--send-all" {
+            // get mature balance from account
+            let balance = account.balance().ok_or_else(|| Error::Custom("Failed to retrieve account balance".into()))?;
+
+            // estimate fee
+            let fee_sompi = account
+                .clone()
+                .estimate(
+                    PaymentDestination::PaymentOutputs(PaymentOutputs::from((address.clone(), balance.mature))),
+                    Fees::ReceiverPays(0),
+                    None,
+                    &abortable,
+                )
+                .await?;
+
+            // subtract estimated and priority fee
+            balance
+                .mature
+                .checked_sub(fee_sompi.aggregated_fees)
+                .ok_or_else(|| Error::Custom("Insufficient funds to cover the transaction fee.".into()))?
+                .checked_sub(priority_fee_sompi.try_into().unwrap_or(0))
+                .ok_or_else(|| Error::Custom("Insufficient funds to cover the priority fee.".into()))?
+        } else {
+            // parse amount if not using --send-all
+            try_parse_required_nonzero_spectre_as_sompi_u64(argv.get(1))?
+        };
+
+        let outputs = PaymentOutputs::from((address.clone(), amount_sompi));
         let (wallet_secret, payment_secret) = ctx.ask_wallet_secret(Some(&account)).await?;
 
         // let ctx_ = ctx.clone();
@@ -40,7 +70,7 @@ impl Send {
 
         tprintln!(ctx, "Transaction sent - {summary}");
         tprintln!(ctx, "\nSending {} SPR to {address}, transaction IDs:", sompi_to_spectre_string(amount_sompi));
-        // tprintln!(ctx, "{}\n", ids.into_iter().map(|a| a.to_string()).collect::<Vec<_>>().join("\n"));
+        tprintln!(ctx, "\n{}\n", _ids.into_iter().map(|a| a.to_string()).collect::<Vec<_>>().join("\n"));
 
         Ok(())
     }

--- a/consensus/src/processes/Parallel Processing.md
+++ b/consensus/src/processes/Parallel Processing.md
@@ -1,100 +1,98 @@
 # Parallel Block Processing
 
-A design document intended to guide the new concurrent implementation
-of header and block processing.
+A design document intended to guide the new concurrent implementation of header and block processing.
 
 ## Sequential processing flow (in go-spectred)
 
-Below we detail the current state of affairs in *go-spectred* and
-discuss future parallelism opportunities. Processing dependencies
-between various stages are detailed in square brackets [***deps; type***].
+Below we detail the current state of affairs in _go-spectred_ and discuss future parallelism opportunities. Processing dependencies between various stages are detailed in square brackets [***deps; type***].
 
 ### Header processing
 
-* Pre pow (aka "*header in isolation*" -- no DB writes to avoid spamming):
-    * block version
-    * timestamp not in future
-    * parents limit (>0 AND <= limit)
-* Pow:
-    * parents not "virtual genesis"
-    * parent headers exist [***headers; read***]
-        * (returns either invalid parent error or missing parents list)
-    * stage parents at all levels (stages topology manager; drops missing parents from level > 0; uses virtual genesis if no parents) [***relations; write***]
-    * verify parents are antichain (reachability manager DAG queries) [***reachability; read***]
-    * verify block is in pruning point future (uses reachability queries on parents) [***reachability; read***]
-    * check pow of block (against block declared target)
-    * check difficulty and blue work
-        * run GHOSTDAG and stage [***reachability; read*** | ***ghostdag; write***]
-        * calculate DAA window and stage; compute difficulty from window; [***windows; read | write***]
-        * verify bits from calculated difficulty
-* Post pow (aka "*header in context*"):
-    * validate median time (uses median time window) [***windows; read***]
-    * check mergeset size limit (could be done following GHOSTDAG)
-    * stage reachability data [***reachability; write***]
-    * check indirect parents (level > 0) [***headers | relations | reachability; read***]
-    * check bounded merge depth [***reachability; read | merge root store; write | finality store; write***]
-    * check DAA score
-    * check header blue work and blue score
-    * validate header pruning point [***reachability | pruning store; read***]
-* Commit all changes
+- Pre-POW (aka "_header in isolation_" -- no DB writes to avoid spamming):
+  - block version
+  - timestamp not in future
+  - parents limit (>0 AND <= limit)
+- POW:
+  - parents not "virtual genesis"
+  - parent headers exist [***headers; read***]
+    - (returns either invalid parent error or missing parents list)
+  - stage parents at all levels (stages topology manager; drops missing parents from level > 0; uses virtual genesis if no parents) [***relations; write***]
+  - verify parents are antichain (reachability manager DAG queries) [***reachability; read***]
+  - verify block is in pruning point future (uses reachability queries on parents) [***reachability; read***]
+  - check POW of block (against block declared target)
+  - check difficulty and blue work
+    - run GHOSTDAG and stage [***reachability; read*** | ***ghostdag; write***]
+    - calculate DAA window and stage; compute difficulty from window; [***windows; read | write***]
+    - verify bits from calculated difficulty
+- Post-POW (aka "_header in context_"):
+  - validate median time (uses median time window) [***windows; read***]
+  - check mergeset size limit (could be done following GHOSTDAG)
+  - stage reachability data [***reachability; write***]
+  - check indirect parents (level > 0) [***headers | relations | reachability; read***]
+  - check bounded merge depth [***reachability; read | merge root store; write | finality store; write***]
+  - check DAA score
+  - check header blue work and blue score
+  - validate header pruning point [***reachability | pruning store; read***]
+- Commit all changes
 
 ### Block processing
 
-* Block body in isolation:
-    * verify all txs have utxo inputs
-    * verify block merkle root
-    * verify at least one tx
-    * verify first tx is coinbase
-    * verify all others are non-coinbase
-    * check coinbase blue score
-    * check txs are ordered by subnet ID
-    * for each tx, validate tx in isolation (includes anything that can be checked w/o context)
-    * check block mass
-    * check if duplicate txs
-    * check double spends
-    * validate gas limit
+- Block body in isolation:
 
-* Block body in context
-    * check block is not pruned (reachability queries from all tips -- relies on reachability data of current block)
-    * check all txs are finalized based on pov DAA score and median time
-    * check parent bodies exist
-    * check coinbase subsidy
-* Stage and commit block body and block status
+  - verify all transactions have UTXO inputs
+  - verify block Merkle root
+  - verify at least one transaction
+  - verify first transaction is coinbase
+  - verify all others are non-coinbase
+  - check coinbase blue score
+  - check transactions are ordered by subnet ID
+  - for each transaction, validate it in isolation (includes anything that can be checked without context)
+  - check block mass
+  - check for duplicate transactions
+  - check double spends
+  - validate gas limit
 
-### Virtual-state processing (block UTXO data -- for context of chain blocks only)
+- Block body in context:
+  - check block is not pruned (reachability queries from all tips -- relies on reachability data of current block)
+  - check all transactions are finalized based on PoV DAA score and median time
+  - check parent bodies exist
+  - check coinbase subsidy
+- Stage and commit block body and block status
 
-* (*roughly*)
-* build the utxo state for selected parent through utxo diffs from virtual
-* build the utxo state for current block based on selected parent state and tx data from the mergeset
-* stage acceptance data
-* update diff paths to virtual
-* update virtual state
+### Virtual-state processing (block UTXO data -- for the context of chain blocks only)
+
+- (_roughly_)
+- build the UTXO state for selected parent through UTXO diffs from virtual
+- build the UTXO state for the current block based on selected parent state and transaction data from the mergeset
+- stage acceptance data
+- update diff paths to virtual
+- update virtual state
 
 ## Parallel processing -- Discussion
 
-There are two levels of possible concurrency to support: (i) process the various stages concurrently in a *pipeline*, i.e., when a block moves to body processing, other headers can enter the header processing stage, and so on; (ii) *parallelism* within each processing "station" of the pipeline, i.e., within header processing, allow *n* independent blocks to be processed in parallel.
+There are two levels of possible concurrency to support: (i) process the various stages concurrently in a _pipeline_, i.e., when a block moves to body processing, other headers can enter the header processing stage, and so on; (ii) _parallelism_ within each processing "station" of the pipeline, i.e., within header processing, allowing _n_ independent blocks to be processed in parallel.
 
 ### Pipeline concurrency
 
-The current code design (*go-spectred*) already logically supports this since the various processing stages were already decoupled for supporting efficient IBD.
+The current code design (_go-spectred_) already logically supports this since the various processing stages were already decoupled for supporting efficient IBD.
 
 ### Header processing parallelism
 
-If you analyze the dependency graph above you can see this is the most challenging part. For instance, we cannot easily create multiple staging areas in parallel, since committing them with out synchronization will introduce logical write conflicts.
+If you analyze the dependency graph above, you can see this is the most challenging part. For instance, we cannot easily create multiple staging areas in parallel, since committing them without synchronization will introduce logical write conflicts.
 
 #### **Natural DAG parallelism**
 
-Throughout header processing, the computation naturally depends on previous output from parents and ancestors of the currently processed header. This means we cannot concurrently process a block with its ancestors, however we can concurrently process blocks which are parallel to each other in the DAG structure (i.e. blocks which are in the anticone of each other). As we increase block rate, more blocks will be mined in parallel -- thus creating more parallelism opportunities as well.
+Throughout header processing, the computation naturally depends on previous output from parents and ancestors of the currently processed header. This means we cannot concurrently process a block with its ancestors, however, we can concurrently process blocks that are parallel to each other in the DAG structure (i.e., blocks which are in the anticone of each other). As we increase block rate, more blocks will be mined in parallel — thus creating more parallelism opportunities as well.
 
-This logic is already implement in `pipeline::HeaderProcessor` struct. The code uses a simple DAG-dependency mechanism to delay processing tasks until all depending tasks are completed. If there are no dependencies, a `rayon::spawn` assigns a thread-pool worker to the ready-to-be processed header.
+This logic is already implemented in the `pipeline::HeaderProcessor` struct. The code uses a simple DAG-dependency mechanism to delay processing tasks until all depending tasks are completed. If there are no dependencies, a `rayon::spawn` assigns a thread-pool worker to the ready-to-be processed header.
 
 #### **Managing store writes**
 
-Most of DB writes during header processing are append-only. That is, a new item is inserted to the store for the new header, and it is never modified in the future. This semantic means that no lock is needed in order to write to such a store as long as we verify that only a single worker thread "owns" each header (`DbGhostdagStore` is an example; note that the DB and cache instances used therein already support concurrency).
+Most of the DB writes during header processing are append-only. That is, a new item is inserted into the store for the new header, and it is never modified in the future. This semantic means that no lock is needed to write to such a store as long as we verify that only a single worker thread "owns" each header (`DbGhostdagStore` is an example; note that the DB and cache instances used therein already support concurrency).
 
-There are two exceptions to this: reachability and relations stores are both non-append-only. We currently assume that their processing time is negligible compared to overall header processing and thus use serialized upgradable-read/write locks in order to manage this part. See `pipeline::HeaderProcessor::commit_header`.
+There are two exceptions to this: reachability and relations stores are both non-append-only. We currently assume that their processing time is negligible compared to overall header processing and thus use serialized upgradable-read/write locks to manage this part. See `pipeline::HeaderProcessor::commit_header`.
 
-Current design should be benchmarked when header processing is fully implemented. If the reachability algorithms are a bottleneck, we can consider moving reachability and relations writes to a new processing unit named "Header DAG processing". This unit will support adding multiple blocks at one call to the reachability tree by performing a single reindexing for all (can be easily supported by current algos).
+The current design should be benchmarked when header processing is fully implemented. If the reachability algorithms are a bottleneck, we can consider moving reachability and relations writes to a new processing unit named "Header DAG processing". This unit will support adding multiple blocks at one call to the reachability tree by performing a single reindexing for all (can be easily supported by current algorithms).
 
 ### Block processing parallelism
 
@@ -102,7 +100,7 @@ Seems straightforward.
 
 ### Virtual processing parallelism
 
-* Process each chain block + mergeset sequentially.
-* Within each such step:
-    * txs within each block can be validated against the utxo set in parallel
-    * blocks in the mergeset and txs within can be processed in parallel based on the consensus-agreed topological mergeset ordering -- however conflicts might arise and need to be taken care of according to said order.
+- Process each chain block + mergeset sequentially.
+- Within each such step:
+  - transactions within each block can be validated against the UTXO set in parallel
+  - blocks in the mergeset and transactions within them can be processed in parallel based on the consensus-agreed topological mergeset ordering -- however, conflicts might arise and need to be resolved according to said order.

--- a/docs/testnet11.md
+++ b/docs/testnet11.md
@@ -1,72 +1,91 @@
 # Testnet 11
 
-*Testnet 11* is the network where we will launch the first public 10BPS Spectre experiment. The goal of this document is to provide a quick guide for anyone who wants to participate.
+_Testnet 11_ is the network where we will launch the first public 10BPS Spectre experiment. This document aims to provide a quick guide for anyone who wants to participate.
 
-In the future testnet 11 will act as a staging zone for all sorts of crazy experiments, allowing us to stress test various approaches and ideas on a global scale with the participation of the community. The approaches we decide to adopt will then be stress tested for longer periods on testnet 10 before being incorporated into the mainnet.
+In the future, Testnet 11 will act as a staging zone for various experiments, allowing us to stress test different approaches and ideas on a global scale with community participation. The approaches we decide to adopt will be stress-tested for longer periods on Testnet 10 before being incorporated into the mainnet.
 
 ## Overview
 
 On the software side, participating requires three components:
-1. *spectred* - the Spectre client
-2.  *spectre-miner* - the Spectre CPU miner
-3.  *Rothschild* - a transaction generator
 
-The Rothschild tool is used to create a wallet, and once the wallet has some funds within, Rothschild will continuously create transactions from that wallet back to itself at the prescribed rate.
+1. **_spectred_** - the Spectre client
+2. **_spectre-miner_** - the Spectre CPU miner
+3. **_Rothschild_** - a transaction generator
 
-The Rothschild wallet could be funded by either mining to it directly (either for a short period or continuously) or by asking other experiment participants for some funds (e.g. on the Discord \#testnet channel).
+The Rothschild tool is used to create a wallet, and once the wallet has some coins, Rothschild will continuously create transactions from that wallet back to itself at the prescribed rate.
 
-## How to participate
+The Rothschild wallet can be funded either by mining to it directly (for a short period or continuously) or by asking other experiment participants for some coins (e.g., on the Discord \#testnet channel).
 
-The only prerequisite is running a node that's connected to Testnet 11. Other than that you produce blocks by running a miner, produce transactions by running Rothschild, or both.
+## How to Participate
 
-Since we want the test condition to be as close as possible to organic, we encourage users to diversify their roles, and the hardware they use to participate.
+The only prerequisite is running a node connected to Testnet 11. From there, you can either produce blocks by running a miner, generate transactions by running Rothschild, or do both.
 
-The venue for discussing and monitoring the experiment will be the \#testnet channel on Discord. We encourage participants to describe the experience in general, and also tell us what hardware they are using and how well it handles the load.
+To simulate a real-world scenario as closely as possible, we encourage participants to diversify their roles and the hardware they use.
 
-The recommended hardware requirements are 16GB of RAM, preferably a CPU with at least 8 cores, and an SSD drive with at least 250GB of free space (the 300GB for a safety margin is preferable). It might also be possible to operate with 8GB of RAM, by passing the `--ram-scale=0.6` parameter to `spectred`.
+The venue for discussing and monitoring the experiment will be the \#testnet channel on Discord. We encourage participants to share their experience and hardware specifications, along with how well their systems handle the load.
+
+### Recommended Hardware Requirements
+
+- 16GB of RAM (8GB may work with the `--ram-scale=0.6` parameter)
+- CPU with at least 8 cores
+- SSD with at least 250GB of free space (300GB for a safety margin)
 
 ## Setup Instructions
 
-Testnet11 uses a dedicated P2P port (18311) so that nodes from the usual testnet (10) do not automatically attempt connecting to it.
+Testnet 11 uses a dedicated P2P port (18311), ensuring that nodes from other testnets (like Testnet 10) don’t automatically connect to it.
 
-We reiterate that only the included miner should be used to maintain a level playing field.
+We emphasize that **only the included miner should be used** to maintain fairness.
 
-First, we set-up a node:
-1. Download and extract the [rusty-spectre binaries](https://github.com/spectre-project/rusty-spectre/releases). Alternatively, you can compile it from source yourself by following the instructions [here](https://github.com/spectre-project/rusty-spectre/blob/main/README.md). The rest of the instructions are written assuming the former option. If you choose to locally compile the code, replace any command of the form ``<program> <arguments>`` with ``cargo run --bin <program> --release -- <arguments>`` (see example in the next item). All actions described below should be performed on a command line window where you navigated to the directory into which the binaries were extracted.
-2. Start the ``spectred`` client with ``utxoindex`` enabled:
+### Step 1: Set Up a Node
 
-```
-spectred --testnet --netsuffix=11 --utxoindex
-```
-  It is **very important** not to forget the ``--netsuffix=11`` flag, otherwise your node will connect to mainnet or to the default 1 BPS testnet.
-  If you complied the code yourself, you should instead run
-```
-cargo run --bin spectred --release -- --testnet --netsuffix=11 --utxoindex
-```
-  Leave this window open, there is no need to touch it as long as the node is running. Closing it will stop the node.
-  
-If you want to transmit transactions, first create a Rothschild wallet
-1. Run ``rothschild`` to generate a wallet
-2. The output will provide you with a private key (that looks like a bunch of gibberish) and a public address (that looks like "spectretest:" followed by a bunch of gibberish). For example, the output could look like this:
-     ```
-     2023-06-25 18:00:58.677+00:00 [INFO ] Connected to RPC
-     2023-06-25 18:00:58.677+00:00 [INFO ] Generated private key aa1c554386218eb28c4bsf6a02e5943799cf951dac7301324d88dec2d0119fce and address spectretest:qzlpwt49f0useql6w0tzpnf8k2symdv5tu2x2pe9r9nvngw8mvx57q0tt9lr5. Send some funds to this address and rerun rothschild with `--private-key aa1c554386218eb28c4bsf6a02e5943799cf951dac7301324d88dec2d0119fce`
-      ```
-     Here, the private key is ```aa1c554386218eb28c4bsf6a02e5943799cf951dac7301324d88dec2d0119fce``` and the address is ```spectretest:qzlpwt49f0useql6w0tzpnf8k2symdv5tu2x2pe9r9nvngw8mvx57q0tt9lr5```
-3. Put some money into the wallet. This could be done by either mining to that wallet (see below) or asking other participants to send money to your public address in the \#testnet Discord channel.
-4. Once the wallet has been funded, run Rothschild with the private key:
+1. Download and extract the [rusty-spectre binaries](https://github.com/spectre-project/rusty-spectre/releases). Alternatively, you can compile it from source by following [these instructions](https://github.com/spectre-project/rusty-spectre/blob/main/README.md). This guide assumes you are using the precompiled binaries. If compiling locally, adjust commands like `<program> <arguments>` to `cargo run --bin <program> --release -- <arguments>`.
+
+   All commands below should be run from the directory where the binaries were extracted.
+
+2. Start the `spectred` client with `utxoindex` enabled:
+
+   ```
+   spectred --testnet --netsuffix=11 --utxoindex
+   ```
+
+   Be sure not to forget the `--netsuffix=11` flag, as omitting it will connect your node to the mainnet or the default 1 BPS testnet. If you compiled the code yourself, run:
+
+   ```
+   cargo run --bin spectred --release -- --testnet --netsuffix=11 --utxoindex
+   ```
+
+   Keep this window open, as closing it will stop the node.
+
+### Step 2: Set Up a Rothschild Wallet
+
+1. Run `rothschild` to generate a wallet.
+2. The output will provide a private key and a public address. For example:
+
+   ```
+   2023-06-25 18:00:58.677+00:00 [INFO ] Connected to RPC
+   2023-06-25 18:00:58.677+00:00 [INFO ] Generated private key aa1c554386218eb28c4bsf6a02e5943799cf951dac7301324d88dec2d0119fce and address spectretest:qzlpwt49f0useql6w0tzpnf8k2symdv5tu2x2pe9r9nvngw8mvx57q0tt9lr5. Send some funds to this address and rerun rothschild with `--private-key aa1c554386218eb28c4bsf6a02e5943799cf951dac7301324d88dec2d0119fce`
+   ```
+
+   Here, the private key is `aa1c554386218eb28c4bsf6a02e5943799cf951dac7301324d88dec2d0119fce`, and the address is `spectretest:qzlpwt49f0useql6w0tzpnf8k2symdv5tu2x2pe9r9nvngw8mvx57q0tt9lr5`.
+
+3. Add some coins to the wallet. You can do this by mining to that wallet (see below) or asking other participants to send coins to your public address in the \#testnet Discord channel.
+
+4. Once the wallet is funded, run Rothschild with the private key:
+
    ```
    rothschild --private-key <private-key> -t=50
    ```
-  The last parameter ``-t=50`` means Rothschild will attempt broadcasting 50 transactions per second. We encourage participants to run with different TPS values. However, in order to encourage transaction spread and to simulate organic usage we highly recommend not to go above 100 TPS.
 
-Like spectred, the Rothschild window should remain open and undisturbed.
+   The `-t=50` parameter means Rothschild will attempt to broadcast 50 transactions per second. We encourage users to experiment with different transaction rates, but avoid going over 100 TPS to simulate organic usage.
 
-For mining, grab `spectre-miner` from within the latest [Release](https://github.com/elichai/spectre-miner/releases) and run it with the following flags (**this is currently the only miner that supports testnet-11**):
-    ```
-    spectre-miner --testnet --mining-address <address> -p 18210 -t 1
-    ```
+### Step 3: Start Mining
 
-If you intend to run Rothschild, replace ``<address>`` with the address of the wallet generated by ``rothschild``, you should then wait for a while before your wallet accumulates enough funds. Assuming several dozen participants, 20 minutes should be more than enough. If you just mine for the sake of mining, you could use any address, such as the one provided in the example above. 
+Download `spectre-miner` from the latest [Release](https://github.com/spectre-project/spectre-miner/releases) and run it with the following flags (**this is the only miner that supports Testnet 11**):
 
-Like the Spectred and Rothschild windows, the miner window should also be left undisturbed, and closing it will stop the mining.
+```
+spectre-miner --testnet --mining-address <address> -p 18210 -t 1
+```
+
+If you plan to run Rothschild, replace `<address>` with the address of your Rothschild wallet. Wait for the wallet to accumulate coins (about 20 minutes assuming several participants). If you are mining without running Rothschild, you can use any address, like the example provided above.
+
+Keep the Spectred, Rothschild, and miner windows open while they are running. Closing them will stop their respective processes.

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -3,20 +3,23 @@
 ## Prerequisites
 
 Latest versions of tools:
-* rust 1.70.0+
-* wasm-pack 0.12.1+ https://rustwasm.github.io/wasm-pack/installer/
-* basic-http-server `cargo install basic-http-server`
-(alternatively you can use your favorite flavor of http server, just make sure to match the ports in this example)
+
+- rust 1.70.0+
+- wasm-pack 0.12.1+ https://rustwasm.github.io/wasm-pack/installer/
+- basic-http-server `cargo install basic-http-server`
+  (alternatively you can use your favorite flavor of http server, just make sure to match the ports in this example)
 
 Both WASM and Native applications are built from the same Rust codebase, so they are identical in their functionality.
 
 ## Starting WASM wallet
+
 ```
 cd wasm
 ./build-web
 cd web
 basic-http-server
 ```
+
 Access the web interface at http://localhost:4000 (`4000` is the default basic-http-server port)
 
 ## Starting Native Wallet
@@ -25,6 +28,7 @@ Access the web interface at http://localhost:4000 (`4000` is the default basic-h
 cd native
 cargo run
 ```
+
 Type `help` for additional help or `exit` to quit the application.
 
 ## Basic Operations
@@ -32,6 +36,7 @@ Type `help` for additional help or `exit` to quit the application.
 (this section will be updated later, it is intended for development)
 
 After starting the wallet shell (native of WASM) and starting a local rusty-spectre Spectred node (with `--testnet` and `--utxoindex`), you should perform the following actions:
+
 ```
 network testnet
 server localhost
@@ -44,7 +49,7 @@ create
 - `connect [<address>]` connects to the given server (`network` and `server` are used to determine the desirable connection endpoint if the address is not specified)
 - `create` without arguments (on a new installation) will create a local wallet
 
-At the end, you will get a mnemonic;  preserve that in case you need to reset the wallet storage at a later date.
+At the end, you will get a mnemonic; preserve that in case you need to reset the wallet storage at a later date.
 
 If receiving a lot of transactions, you can use `mute` and `track <type>` commands to mute and toggle specific types of notifications.
 


### PR DESCRIPTION
* based on #23 with transaction fee estimation included in the total amount available for send
* added `--send-all` option to `send` command, allowing users to send their entire mature balance minus an optional priority fee
* retains feature parity between Go and Rust implementations (the Go wallet has `--send-all`)
* fix formatting and typos