### PR TITLE
bindgen target override for gnullvm build

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -226,6 +226,7 @@ jobs:
         # We're using clang to link only the ucrt library statically.
         env:
           RUSTFLAGS: -L/clang64/lib -lstatic=c++
+          BINDGEN_EXTRA_CLANG_ARGS: "--target=x86_64-pc-windows-msvc"
         shell: msys2 {0}
         run: |
           export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin" # manually override path to select proper msys2 build tools.


### PR DESCRIPTION
(temporary solution)
Related to the issue described in https://github.com/rust-lang/cc-rs/issues/1167 where the gnullvm target triple is incompatible with LLVM19. So we force bindgen to use a well supported target when parsing C headers, while still compiling for `gnullvm` target.