### PR TITLE
replace zigbuild with custom musl toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,17 +347,26 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
-      - name: Install zig
-        if: runner.os == 'Linux'
-        uses: goto-bus-stop/setup-zig@v2 # needed for cargo-zigbuild
+      - name: Cache Toolchain
+        uses: actions/cache@v4
         with:
-          version: 0.13.0
+          path: |
+            ~/x-tools
+          key: ${{ runner.os }}-musl-${{ hashFiles('**/musl-toolchain/build-amd64.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-musl-
 
-      - name: Build on Linux
+      - name: Build on Linux with musl toolchain
         if: runner.os == 'Linux'
-
-        # We're using musl to make the binaries statically linked and portable
         run: |
-          cargo install cargo-zigbuild
-          cargo --verbose zigbuild --bin spectred --bin simpa --bin rothschild --release --target x86_64-unknown-linux-gnu.2.27 # Use an older glibc version
+          rustup target add x86_64-unknown-linux-musl
+          cargo fetch --target x86_64-unknown-linux-musl
+
+          # Run build script for musl toolchain
+          source musl-toolchain/build-amd64.sh
+
+          # Build for musl
+          cargo --verbose build --bin spectred --bin rothschild --bin spectre-wallet --release --target x86_64-unknown-linux-musl

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,10 +56,19 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install zig on Linux
-        if: runner.os == 'Linux'
+        if: matrix.TARGET == 'linux-musl/aarch64'
         uses: goto-bus-stop/setup-zig@v2 # needed for cargo-zigbuild
         with:
           version: 0.13.0
+
+      - name: Cache Toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/x-tools
+          key: ${{ runner.os }}-musl-${{ hashFiles('**/musl-toolchain/build-amd64.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-musl-
 
       - name: Install protoc on Linux
         if: runner.os == 'Linux'
@@ -89,12 +98,10 @@ jobs:
         run: |
           rustup target add x86_64-unknown-linux-gnu
           cargo build --target x86_64-unknown-linux-gnu --bin spectred --release
-          cargo build --target x86_64-unknown-linux-gnu --bin simpa --release
           cargo build --target x86_64-unknown-linux-gnu --bin rothschild --release
           cargo build --target x86_64-unknown-linux-gnu --bin spectre-wallet --release
           mkdir bin || true
           cp target/x86_64-unknown-linux-gnu/release/spectred bin/
-          cp target/x86_64-unknown-linux-gnu/release/simpa bin/
           cp target/x86_64-unknown-linux-gnu/release/rothschild bin/
           cp target/x86_64-unknown-linux-gnu/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-linux-gnu-amd64.zip"
@@ -110,12 +117,10 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           rustup target add aarch64-unknown-linux-gnu
           cargo build --target aarch64-unknown-linux-gnu --bin spectred --release
-          cargo build --target aarch64-unknown-linux-gnu --bin simpa --release
           cargo build --target aarch64-unknown-linux-gnu --bin rothschild --release
           cargo build --target aarch64-unknown-linux-gnu --bin spectre-wallet --release
           mkdir bin || true
           cp target/aarch64-unknown-linux-gnu/release/spectred bin/
-          cp target/aarch64-unknown-linux-gnu/release/simpa bin/
           cp target/aarch64-unknown-linux-gnu/release/rothschild bin/
           cp target/aarch64-unknown-linux-gnu/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-linux-gnu-aarch64.zip"
@@ -131,12 +136,10 @@ jobs:
           sudo apt-get install -y gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
           rustup target add riscv64gc-unknown-linux-gnu
           cargo build --target riscv64gc-unknown-linux-gnu --bin spectred --release
-          cargo build --target riscv64gc-unknown-linux-gnu --bin simpa --release
           cargo build --target riscv64gc-unknown-linux-gnu --bin rothschild --release
           cargo build --target riscv64gc-unknown-linux-gnu --bin spectre-wallet --release
           mkdir bin || true
           cp target/riscv64gc-unknown-linux-gnu/release/spectred bin/
-          cp target/riscv64gc-unknown-linux-gnu/release/simpa bin/
           cp target/riscv64gc-unknown-linux-gnu/release/rothschild bin/
           cp target/riscv64gc-unknown-linux-gnu/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-linux-gnu-riscv64gc.zip"
@@ -152,12 +155,10 @@ jobs:
           sudo apt-get install -y gcc-powerpc64-linux-gnu g++-powerpc64-linux-gnu
           rustup target add powerpc64-unknown-linux-gnu
           cargo build --target powerpc64-unknown-linux-gnu --bin spectred --release
-          cargo build --target powerpc64-unknown-linux-gnu --bin simpa --release
           cargo build --target powerpc64-unknown-linux-gnu --bin rothschild --release
           cargo build --target powerpc64-unknown-linux-gnu --bin spectre-wallet --release
           mkdir bin || true
           cp target/powerpc64-unknown-linux-gnu/release/spectred bin/
-          cp target/powerpc64-unknown-linux-gnu/release/simpa bin/
           cp target/powerpc64-unknown-linux-gnu/release/rothschild bin/
           cp target/powerpc64-unknown-linux-gnu/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-linux-gnu-powerpc64.zip"
@@ -173,12 +174,10 @@ jobs:
           sudo apt-get install -y gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu
           rustup target add powerpc64le-unknown-linux-gnu
           cargo build --target powerpc64le-unknown-linux-gnu --bin spectred --release
-          cargo build --target powerpc64le-unknown-linux-gnu --bin simpa --release
           cargo build --target powerpc64le-unknown-linux-gnu --bin rothschild --release
           cargo build --target powerpc64le-unknown-linux-gnu --bin spectre-wallet --release
           mkdir bin || true
           cp target/powerpc64le-unknown-linux-gnu/release/spectred bin/
-          cp target/powerpc64le-unknown-linux-gnu/release/simpa bin/
           cp target/powerpc64le-unknown-linux-gnu/release/rothschild bin/
           cp target/powerpc64le-unknown-linux-gnu/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-linux-gnu-powerpc64le.zip"
@@ -187,16 +186,19 @@ jobs:
       - name: Build on Linux for linux-musl/amd64
         if: matrix.TARGET == 'linux-musl/amd64'
 
-        # We're using musl to make the binaries statically linked and portable.
-        env:
-          RUSTFLAGS: -C target-feature=-crt-static
+        # We're using musl to make the binaries statically linked and portable
         run: |
           rustup target add x86_64-unknown-linux-musl
-          cargo install cargo-zigbuild
-          cargo --verbose zigbuild --bin spectred --bin simpa --bin rothschild --bin spectre-wallet --release --target x86_64-unknown-linux-musl
+          cargo fetch --target x86_64-unknown-linux-musl
+
+          # Run build script for musl toolchain.
+          source musl-toolchain/build-amd64.sh
+          cd "${GITHUB_WORKSPACE}"
+
+          # Build for musl.
+          cargo --verbose build --bin spectred --bin rothschild --bin spectre-wallet --release --target x86_64-unknown-linux-musl
           mkdir bin || true
           cp target/x86_64-unknown-linux-musl/release/spectred bin/
-          cp target/x86_64-unknown-linux-musl/release/simpa bin/
           cp target/x86_64-unknown-linux-musl/release/rothschild bin/
           cp target/x86_64-unknown-linux-musl/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-linux-musl-amd64.zip"
@@ -206,15 +208,18 @@ jobs:
         if: matrix.TARGET == 'linux-musl/aarch64'
 
         # We're using musl to make the binaries statically linked and portable.
-        env:
-          RUSTFLAGS: -C target-feature=-crt-static
         run: |
           rustup target add aarch64-unknown-linux-musl
-          cargo install cargo-zigbuild
-          cargo --verbose zigbuild --bin spectred --bin simpa --bin rothschild --bin spectre-wallet --release --target aarch64-unknown-linux-musl
+          cargo fetch --target aarch64-unknown-linux-musl
+
+          # Run build script for musl toolchain.
+          source musl-toolchain/build-aarch64.sh
+          cd "${GITHUB_WORKSPACE}"
+
+          # Build for musl.
+          cargo --verbose build --bin spectred --bin rothschild --bin spectre-wallet --release --target aarch64-unknown-linux-musl
           mkdir bin || true
           cp target/aarch64-unknown-linux-musl/release/spectred bin/
-          cp target/aarch64-unknown-linux-musl/release/simpa bin/
           cp target/aarch64-unknown-linux-musl/release/rothschild bin/
           cp target/aarch64-unknown-linux-musl/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-linux-musl-aarch64.zip"
@@ -240,12 +245,10 @@ jobs:
             https://repo.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-llvm-libs-18.1.8-2-any.pkg.tar.zst
           rustup target add x86_64-pc-windows-gnullvm
           cargo build --target x86_64-pc-windows-gnullvm --bin spectred --release
-          cargo build --target x86_64-pc-windows-gnullvm --bin simpa --release
           cargo build --target x86_64-pc-windows-gnullvm --bin rothschild --release
           cargo build --target x86_64-pc-windows-gnullvm --bin spectre-wallet --release
           mkdir bin || true
           cp target/x86_64-pc-windows-gnullvm/release/spectred.exe bin/
-          cp target/x86_64-pc-windows-gnullvm/release/simpa.exe bin/
           cp target/x86_64-pc-windows-gnullvm/release/rothschild.exe bin/
           cp target/x86_64-pc-windows-gnullvm/release/spectre-wallet.exe bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-windows-gnullvm-amd64.zip"
@@ -258,12 +261,10 @@ jobs:
           export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin" # manually override path to select proper msys2 build tools.
           rustup target add x86_64-pc-windows-msvc
           cargo build --target x86_64-pc-windows-msvc --bin spectred --release
-          cargo build --target x86_64-pc-windows-msvc --bin simpa --release
           cargo build --target x86_64-pc-windows-msvc --bin rothschild --release
           cargo build --target x86_64-pc-windows-msvc --bin spectre-wallet --release
           mkdir bin || true
           cp target/x86_64-pc-windows-msvc/release/spectred.exe bin/
-          cp target/x86_64-pc-windows-msvc/release/simpa.exe bin/
           cp target/x86_64-pc-windows-msvc/release/rothschild.exe bin/
           cp target/x86_64-pc-windows-msvc/release/spectre-wallet.exe bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-windows-msvc-amd64.zip"
@@ -274,12 +275,10 @@ jobs:
         run: |
           rustup target add x86_64-apple-darwin
           cargo build --target x86_64-apple-darwin --bin spectred --release
-          cargo build --target x86_64-apple-darwin --bin simpa --release
           cargo build --target x86_64-apple-darwin --bin rothschild --release
           cargo build --target x86_64-apple-darwin --bin spectre-wallet --release
           mkdir bin || true
           cp target/x86_64-apple-darwin/release/spectred bin/
-          cp target/x86_64-apple-darwin/release/simpa bin/
           cp target/x86_64-apple-darwin/release/rothschild bin/
           cp target/x86_64-apple-darwin/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-macos-amd64.zip"
@@ -290,12 +289,10 @@ jobs:
         run: |
           rustup target add aarch64-apple-darwin
           cargo build --target aarch64-apple-darwin --bin spectred --release
-          cargo build --target aarch64-apple-darwin --bin simpa --release
           cargo build --target aarch64-apple-darwin --bin rothschild --release
           cargo build --target aarch64-apple-darwin --bin spectre-wallet --release
           mkdir bin || true
           cp target/aarch64-apple-darwin/release/spectred bin/
-          cp target/aarch64-apple-darwin/release/simpa bin/
           cp target/aarch64-apple-darwin/release/rothschild bin/
           cp target/aarch64-apple-darwin/release/spectre-wallet bin/
           archive="bin/rusty-spectre-${{ github.event.release.tag_name }}-macos-aarch64.zip"

--- a/musl-toolchain/build-aarch64.sh
+++ b/musl-toolchain/build-aarch64.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/bash
+
+# Config presets.
+PRESET_HASH_FILE="${HOME}/x-tools/aarch64_preset_hash"
+CTNG_PRESET="aarch64-unknown-linux-musl"
+
+# Calculate and show the hash of this script file.
+CURRENT_PRESET_HASH=$(sha256sum ${GITHUB_WORKSPACE}/musl-toolchain/build-aarch64.sh | awk '{print $1}')
+echo "Current preset hash: ${CURRENT_PRESET_HASH}"
+
+# Traverse to working directory.
+cd "${GITHUB_WORKSPACE}/musl-toolchain"
+
+# If the toolchain is not installed or the preset has changed or the preset hash file does not exist.
+if [ ! -d "${HOME}/x-tools/${CTNG_PRESET}" ] || [ ! -f "${PRESET_HASH_FILE}" ] || [ "$(cat ${PRESET_HASH_FILE})" != "${CURRENT_PRESET_HASH}" ]; then
+
+  # Install dependencies.
+  sudo apt-get update
+  sudo apt-get install -y autoconf automake libtool libtool-bin unzip help2man python3-dev gperf bison flex texinfo gawk libncurses5-dev libc6-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
+
+  # Clone crosstool-ng.
+  git clone https://github.com/crosstool-ng/crosstool-ng
+
+  # Configure and build crosstool-ng.
+  cd crosstool-ng
+
+  # Use version 1.27.
+  git checkout crosstool-ng-1.27.0
+  ./bootstrap
+  ./configure "--prefix=${HOME}/ctng"
+  make
+  make install
+
+  # Add crosstool-ng to PATH.
+  export PATH="${HOME}/ctng/bin:${PATH}"
+
+  # Load toolchain configuration.
+  ct-ng "${CTNG_PRESET}"
+
+  # Build the toolchain.
+  ct-ng build > build.log 2>&1
+
+  # Set status to the exit code of the build.
+  status="${?}"
+
+  # We store the log in a file because it bloats the screen too much
+  # on GitHub Actions. We print it only if the build fails.
+  echo "Build result:"
+  if [ "${status}" -eq 0 ]; then
+    echo "Build succeeded"
+    ls -la "${HOME}/x-tools"
+
+    # Store the current hash of this script after successful build.
+    echo "${CURRENT_PRESET_HASH}" > "${PRESET_HASH_FILE}"
+  else
+    echo "Build failed, here's the log:"
+    cat .config
+    cat build.log
+    exit 1
+  fi
+fi
+
+# Update toolchain variables: C compiler, C++ compiler, linker, and archiver.
+export CC="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-gcc"
+export CXX="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-g++"
+export LD="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-ld"
+export AR="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-ar"
+
+# Exports for cc crate.
+# https://docs.rs/cc/latest/cc/#external-configuration-via-environment-variables
+export RANLIB_aarch64_unknown_linux_musl="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-ranlib"
+export CC_aarch64_unknown_linux_musl="${CC}"
+export CXX_aarch64_unknown_linux_musl="${CXX}"
+export AR_aarch64_unknown_linux_musl="${AR}"
+export LD_aarch64_unknown_linux_musl="${LD}"
+
+# Set environment variables for static linking.
+export OPENSSL_STATIC="true"
+export RUSTFLAGS="-C link-arg=-static"
+
+# We specify the compiler that will invoke linker.
+export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="${CC}"
+
+# Patch missing include in librocksdb-sys-0.16.0+8.10.0. Credit: @supertypo
+FILE_PATH=$(find "${HOME}/.cargo/registry/src/" -path "*/librocksdb-sys-0.16.0+8.10.0/*/offpeak_time_info.h")
+
+if [ -n "${FILE_PATH}" ]; then
+  sed -i '1i #include <cstdint>' "${FILE_PATH}"
+else
+  echo "No such file for sed modification."
+fi

--- a/musl-toolchain/build-amd64.sh
+++ b/musl-toolchain/build-amd64.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/bash
+
+# Config presets.
+PRESET_HASH_FILE="${HOME}/x-tools/amd64_preset_hash"
+CTNG_PRESET="x86_64-multilib-linux-musl"
+
+# Calculate and show the hash of this script file.
+CURRENT_PRESET_HASH=$(sha256sum ${GITHUB_WORKSPACE}/musl-toolchain/build-amd64.sh | awk '{print $1}')
+echo "Current preset hash: ${CURRENT_PRESET_HASH}"
+
+# Traverse to working directory.
+cd "${GITHUB_WORKSPACE}/musl-toolchain"
+
+# If the toolchain is not installed or the preset has changed or the preset hash file does not exist.
+if [ ! -d "${HOME}/x-tools/${CTNG_PRESET}" ] || [ ! -f "${PRESET_HASH_FILE}" ] || [ "$(cat ${PRESET_HASH_FILE})" != "${CURRENT_PRESET_HASH}" ]; then
+
+  # Install dependencies.
+  sudo apt-get update
+  sudo apt-get install -y autoconf automake libtool libtool-bin unzip help2man python3-dev gperf bison flex texinfo gawk libncurses5-dev
+
+  # Clone crosstool-ng.
+  git clone https://github.com/crosstool-ng/crosstool-ng
+
+  # Configure and build crosstool-ng.
+  cd crosstool-ng
+
+  # Use version 1.27.
+  git checkout crosstool-ng-1.27.0
+  ./bootstrap
+  ./configure "--prefix=${HOME}/ctng"
+  make
+  make install
+
+  # Add crosstool-ng to PATH.
+  export PATH="${HOME}/ctng/bin:${PATH}"
+
+  # Load toolchain configuration.
+  ct-ng "${CTNG_PRESET}"
+
+  # Build the toolchain.
+  ct-ng build > build.log 2>&1
+
+  # Set status to the exit code of the build.
+  status="${?}"
+
+  # We store the log in a file because it bloats the screen too much
+  # on GitHub Actions. We print it only if the build fails.
+  echo "Build result:"
+  if [ "${status}" -eq 0 ]; then
+    echo "Build succeeded"
+    ls -la "${HOME}/x-tools"
+
+    # Store the current hash of this script after successful build.
+    echo "${CURRENT_PRESET_HASH}" > "${PRESET_HASH_FILE}"
+  else
+    echo "Build failed, here's the log:"
+    cat .config
+    cat build.log
+    exit 1
+  fi
+fi
+
+# Update toolchain variables: C compiler, C++ compiler, linker, and archiver.
+export CC="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-gcc"
+export CXX="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-g++"
+export LD="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-ld"
+export AR="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-ar"
+
+# Exports for cc crate.
+# https://docs.rs/cc/latest/cc/#external-configuration-via-environment-variables
+export RANLIB_x86_64_unknown_linux_musl="${HOME}/x-tools/${CTNG_PRESET}/bin/${CTNG_PRESET}-ranlib"
+export CC_x86_64_unknown_linux_musl="${CC}"
+export CXX_x86_64_unknown_linux_musl="${CXX}"
+export AR_x86_64_unknown_linux_musl="${AR}"
+export LD_x86_64_unknown_linux_musl="${LD}"
+
+# Set environment variables for static linking.
+export OPENSSL_STATIC="true"
+export RUSTFLAGS="-C link-arg=-static"
+
+# We specify the compiler that will invoke linker.
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="${CC}"
+
+# Patch missing include in librocksdb-sys-0.16.0+8.10.0. Credit: @supertypo
+FILE_PATH=$(find "${HOME}/.cargo/registry/src/" -path "*/librocksdb-sys-0.16.0+8.10.0/*/offpeak_time_info.h")
+
+if [ -n "${FILE_PATH}" ]; then
+  sed -i '1i #include <cstdint>' "${FILE_PATH}"
+else
+  echo "No such file for sed modification."
+fi


### PR DESCRIPTION
Replace `musl` Linux zigbuilds with `crosstool-ng` builds which will greatly improve stability, several occasional segmentation faults will be fixed with it.

* x86_64 Linux builds
* aarch64 Linux builds